### PR TITLE
Fix RTL alignment

### DIFF
--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -80,7 +80,7 @@ const HeroSection = () => {
             initial={{ opacity: 0, y: 50 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, delay: 0.3, ease: "easeOut" }}
-            className="max-w-lg md:max-w-xl ml-auto text-right rtl:mr-auto rtl:text-left"
+            className="max-w-lg md:max-w-xl ml-auto text-right rtl:mr-auto"
           >
             <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-3 sm:mb-4 leading-tight text-shadow-lg">
               {currentSlide.titleLine1}

--- a/src/components/ui/dialog.jsx
+++ b/src/components/ui/dialog.jsx
@@ -42,7 +42,7 @@ const DialogContent = React.forwardRef(({ className, children, ...props }, ref) 
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({ className, ...props }) => (
-  <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+  <div className={cn('flex flex-col space-y-2 text-center sm:text-right', className)} {...props} />
 )
 DialogHeader.displayName = 'DialogHeader'
 

--- a/src/pages/AudiobookPage.jsx
+++ b/src/pages/AudiobookPage.jsx
@@ -132,7 +132,7 @@
             </div>
 
             {/* Text and Button Section (Right side) */}
-            <div className="text-center md:text-right rtl:md:text-left max-w-lg md:max-w-md md:mr-auto">
+            <div className="text-center md:text-right max-w-lg md:max-w-md md:mr-auto">
               <h1 className="text-3xl sm:text-4xl lg:text-5xl font-extrabold mb-3 leading-tight text-shadow-lg">
                 اختر باقة الاستماع المناسبة لك
               </h1>
@@ -228,7 +228,7 @@
                   </motion.div>
                 ))}
               </div>
-              <div className="md:w-1/2 text-center md:text-right rtl:md:text-left">
+              <div className="md:w-1/2 text-center md:text-right">
                 <h2 className="text-2xl sm:text-3xl font-bold text-gray-800 mb-3">قصص مختارة بعناية</h2>
                 <p className="text-gray-600 text-sm sm:text-base mb-6">
                   تابع مؤلفات أو رواة في مسلسلاتك المفضلة، واحصل على توصيات
@@ -263,7 +263,7 @@
                 ))}
               </div>
 
-              <div className="md:w-1/2 text-center md:text-right rtl:md:text-left">
+              <div className="md:w-1/2 text-center md:text-right">
                 <h2 className="text-2xl sm:text-3xl font-bold text-gray-800 mb-3">في أي وقت، وفي أي مكان.</h2>
                 <p className="text-gray-600 text-sm sm:text-base mb-6">
                   استمع إلى الكتب الصوتية المفضلة لديك أينما كنت. قم بتنزيل كتبك للاستماع إليها دون اتصال بالإنترنت.

--- a/src/pages/AuthorPage.jsx
+++ b/src/pages/AuthorPage.jsx
@@ -49,7 +49,7 @@ const AuthorPage = ({ authors, books, handleAddToCart, handleToggleWishlist }) =
               className="w-full h-full object-cover"
              src="https://images.unsplash.com/photo-1572119003128-d110c07af847" />
           </div>
-          <div className="text-center sm:text-right rtl:sm:text-left">
+          <div className="text-center sm:text-right">
             <h1 className="text-3xl sm:text-4xl font-extrabold mb-1.5">{author.name}</h1>
             <p className="text-blue-200 text-sm sm:text-base mb-3">{author.bio || 'مؤلف وكاتب شغوف، يسعى لإثراء المحتوى العربي بأعمال أدبية وفكرية قيمة.'}</p>
             <div className="flex items-center justify-center sm:justify-start space-x-4 rtl:space-x-reverse text-sm">

--- a/src/pages/EbookPage.jsx
+++ b/src/pages/EbookPage.jsx
@@ -58,7 +58,7 @@ const EbookPage = ({ books, authors, handleAddToCart, handleToggleWishlist, wish
         animate={{ opacity: 1, y: 0 }}
         className="bg-gradient-to-br from-blue-600 to-purple-700 p-6 sm:p-8 rounded-xl shadow-2xl flex flex-col md:flex-row items-center justify-between text-white"
       >
-        <div className="text-center md:text-right rtl:md:text-left max-w-lg md:max-w-md">
+        <div className="text-center md:text-right max-w-lg md:max-w-md">
           <h1 className="text-3xl sm:text-4xl lg:text-5xl font-extrabold mb-3 leading-tight">اكتشف أكثر من ٧٠٠٠٠ كتاب إلكتروني</h1>
           <p className="text-lg sm:text-xl mb-1">نحن باقة القراءة المناسبة لك</p>
           <p className="text-blue-100 text-sm sm:text-base mb-6">اكتشف آلاف الكتب من الأطفال، إلى %٥٠ خصم وأكثر في أي وقت</p>


### PR DESCRIPTION
## Summary
- ensure dialog headers align to the right on desktop
- keep hero text right aligned in RTL mode
- remove RTL overrides that forced left alignment in audiobook, author and ebook pages

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d36ac1cd4832a8cbb36e33bb842c6