### PR TITLE
Enhance ebook hero layout

### DIFF
--- a/src/pages/EbookPage.jsx
+++ b/src/pages/EbookPage.jsx
@@ -57,10 +57,11 @@ const EbookPage = ({ books, authors, handleAddToCart, handleToggleWishlist, wish
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         style={{ backgroundImage: "url('https://i.ibb.co/3Y7PkFH7/image-1318.png')" }}
-        className="relative bg-center bg-cover p-6 sm:p-8 rounded-xl shadow-2xl flex flex-col md:flex-row items-center justify-between text-white overflow-hidden"
+        className="relative bg-center bg-cover p-6 sm:p-8 rounded-xl shadow-2xl flex items-center text-white overflow-hidden"
       >
-        <div className="absolute inset-0 bg-black/40"></div>
-        <div className="relative bg-purple-700/80 p-6 sm:p-8 rounded-xl text-center md:text-right max-w-lg md:max-w-md">
+        <div className="absolute inset-0 bg-black/40 z-0" />
+        <div className="absolute inset-y-0 left-0 w-full md:w-1/2 bg-purple-700/80 rounded-r-full z-10" />
+        <div className="relative z-20 p-6 sm:p-8 text-center md:text-right max-w-lg md:max-w-md">
           <h1 className="text-3xl sm:text-4xl lg:text-5xl font-extrabold mb-3 leading-tight">اكتشف أكثر من ٧٠٠٠٠ كتاب إلكتروني</h1>
           <p className="text-lg sm:text-xl mb-1">نحن باقة القراءة المناسبة لك</p>
           <p className="text-blue-100 text-sm sm:text-base mb-6">اكتشف آلاف الكتب من الأطفال، إلى %٥٠ خصم وأكثر في أي وقت</p>


### PR DESCRIPTION
## Summary
- style the Ebook page hero banner so the purple background spans the whole text side with a curved edge

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fbc5730b4832a984107bcd343a35c