### PR TITLE
Match audiobook button styles

### DIFF
--- a/src/pages/AudiobookPage.jsx
+++ b/src/pages/AudiobookPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Check, Award, Star, Play, Clock, Headphones } from 'lucide-react';
+import { Button } from '@/components/ui/button.jsx';
 
 const AudiobookPage = () => {
   // Mock data
@@ -129,7 +130,7 @@ const AudiobookPage = () => {
           </div>
           {/* Button below the book cover */}
           <button
-            className="absolute -bottom-12 sm:-bottom-16 w-full bg-white text-blue-600 hover:bg-blue-50 rounded-full shadow-lg text-base sm:text-lg px-6 py-3 transition-colors"
+            className="absolute -bottom-12 sm:-bottom-16 w-full bg-[#E4E6FF] hover:bg-[#d6d8f2] text-[#315dfb] border border-[#E4E6FF] rounded-full shadow-md text-base sm:text-lg px-6 py-3 transition-colors"
           >
             تصفح الكتب الصوتية
           </button>
@@ -173,15 +174,15 @@ const AudiobookPage = () => {
                   ))}
                 </ul>
 
-                <button
+                <Button
                   className={`w-full py-3 rounded-xl font-medium transition-all duration-200 ${
                     plan.popular
                       ? 'bg-blue-500 hover:bg-blue-600 text-white shadow-lg'
-                      : 'bg-gray-100 hover:bg-gray-200 text-gray-800 border border-gray-300'
+                      : 'bg-[#E4E6FF] hover:bg-[#d6d8f2] text-[#315dfb] border border-[#E4E6FF]'
                   }`}
                 >
                   اختر باقتك
-                </button>
+                </Button>
               </div>
             </motion.div>
           ))}
@@ -251,7 +252,7 @@ const AudiobookPage = () => {
               <p className="text-gray-600 text-sm sm:text-base mb-6">
                 استمع إلى الكتب الصوتية المفضلة لديك أينما كنت. قم بتنزيل كتبك للاستماع إليها دون اتصال بالإنترنت.
               </p>
-              <button className="bg-blue-600 hover:bg-blue-700 text-white text-base py-3 px-8 shadow-lg hover:shadow-xl rounded-lg transition-all">
+              <button className="bg-[#E4E6FF] hover:bg-[#d6d8f2] text-[#315dfb] border border-[#E4E6FF] text-base py-3 px-8 shadow-md rounded-lg transition-all">
                 تصفح الكتب الصوتية
               </button>
             </div>


### PR DESCRIPTION
## Summary
- import shared `Button` component in AudiobookPage
- style audiobook plan buttons like EbookPage plans
- apply same style to both "Browse audiobooks" buttons

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68610a45a488832aae6a2c84560f9f03