### PR TITLE
Fix RTL support

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+const plugin = require('tailwindcss/plugin');
+
 module.exports = {
 	darkMode: ['class'],
 	content: [
@@ -85,5 +87,11 @@ module.exports = {
 			},
 		},
 	},
-	plugins: [require('tailwindcss-animate')],
+        plugins: [
+                require('tailwindcss-animate'),
+                plugin(function({ addVariant }) {
+                        addVariant('rtl', '&[dir="rtl"] &, [dir="rtl"] &');
+                        addVariant('ltr', '&[dir="ltr"] &, [dir="ltr"] &');
+                })
+        ],
 };


### PR DESCRIPTION
## Summary
- add a small Tailwind plugin to enable `rtl:` variant

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686156cad6d8832a9a322ee94bdb2eee