### PR TITLE
Add payment gateway fields to dashboard settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,7 +45,7 @@ const App = () => {
   const [orders, setOrders] = useState(() => JSON.parse(localStorage.getItem('orders') || '[]'));
   const [siteSettingsState, setSiteSettingsState] = useState(() => {
     const stored = localStorage.getItem('siteSettings');
-    return stored ? JSON.parse(stored) : initialSiteSettings;
+    return stored ? { ...initialSiteSettings, ...JSON.parse(stored) } : initialSiteSettings;
   });
   const [cartDialogOpen, setCartDialogOpen] = useState(false);
   const [cartDialogBook, setCartDialogBook] = useState(null);

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -992,6 +992,25 @@ const DashboardSettings = ({ siteSettings, setSiteSettings }) => {
             <Label htmlFor="themeColor">اللون الرئيسي</Label>
             <Input id="themeColor" name="themeColor" type="color" value={formData.themeColor} onChange={handleChange} />
           </div>
+          <div className="md:col-span-2 border-t pt-4">
+            <h4 className="font-semibold mb-2">إعدادات الدفع</h4>
+          </div>
+          <div>
+            <Label htmlFor="stripePublicKey">Stripe Public Key</Label>
+            <Input id="stripePublicKey" name="stripePublicKey" value={formData.stripePublicKey} onChange={handleChange} />
+          </div>
+          <div>
+            <Label htmlFor="stripeSecretKey">Stripe Secret Key</Label>
+            <Input id="stripeSecretKey" name="stripeSecretKey" value={formData.stripeSecretKey} onChange={handleChange} />
+          </div>
+          <div>
+            <Label htmlFor="paypalClientId">PayPal Client ID</Label>
+            <Input id="paypalClientId" name="paypalClientId" value={formData.paypalClientId} onChange={handleChange} />
+          </div>
+          <div>
+            <Label htmlFor="paypalSecret">PayPal Secret</Label>
+            <Input id="paypalSecret" name="paypalSecret" value={formData.paypalSecret} onChange={handleChange} />
+          </div>
         </div>
         <div className="flex justify-end">
           <Button type="submit" className="bg-gradient-to-r from-blue-600 to-purple-600 text-white">

--- a/src/data/siteData.js
+++ b/src/data/siteData.js
@@ -282,5 +282,9 @@ export const siteSettings = {
   facebook: '',
   twitter: '',
   instagram: '',
-  themeColor: '#1D4ED8'
+  themeColor: '#1D4ED8',
+  stripePublicKey: '',
+  stripeSecretKey: '',
+  paypalClientId: '',
+  paypalSecret: ''
 };


### PR DESCRIPTION
## Summary
- add payment integration keys to `siteSettings` defaults
- expose payment fields in dashboard settings form
- preserve new keys when loading settings from storage

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e8ecd568832aaf0cb7073883c368