### PR TITLE
Fix user dropdown direction

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -71,7 +71,7 @@ const Header = ({ handleFeatureClick, cartItemCount }) => {
                   <span>بروس وين</span>
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" className="bg-white shadow-lg rounded-md border border-gray-200 text-gray-800">
+              <DropdownMenuContent dir="rtl" align="end" className="bg-white shadow-lg rounded-md border border-gray-200 text-gray-800">
                 <DropdownMenuItem asChild>
                   <Link to="/profile?tab=wishlist" className="flex items-center">
                     <Bookmark className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />


### PR DESCRIPTION
## Summary
- adjust user dropdown direction so menu aligns to the right in RTL sites

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640286bdd0832aab7c0a81674338d7