### PR TITLE
Implement login state UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -163,6 +163,12 @@ const App = () => {
   };
   
   const handleFeatureClick = (feature) => {
+    if (feature === 'logout') {
+      localStorage.removeItem('customerLoggedIn');
+      setIsCustomerLoggedIn(false);
+      toast({ title: 'تم تسجيل الخروج' });
+      return;
+    }
     toast({
       title: "🚧 هذه الميزة غير مطبقة بعد",
       description: "لا تقلق! سيتم تطبيقها الأيام القادمة",
@@ -190,6 +196,7 @@ const App = () => {
       <Header
         handleFeatureClick={handleFeatureClick}
         cartItemCount={cart.reduce((sum, item) => sum + item.quantity, 0)}
+        isCustomerLoggedIn={isCustomerLoggedIn}
       />
       {children}
       <Footer footerLinks={footerLinks} handleFeatureClick={handleFeatureClick} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -21,7 +21,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator, DropdownMenuLabel } from '@/components/ui/dropdown-menu.jsx';
 
-const Header = ({ handleFeatureClick, cartItemCount }) => {
+const Header = ({ handleFeatureClick, cartItemCount, isCustomerLoggedIn }) => {
   const renderDropdown = (label, items, isCategory = false, hideOnMobile = false) => (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -48,6 +48,52 @@ const Header = ({ handleFeatureClick, cartItemCount }) => {
     </DropdownMenu>
   );
 
+  const renderUserSection = () => {
+    if (isCustomerLoggedIn) {
+      return (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="flex items-center space-x-1 rtl:space-x-reverse hover:text-blue-200">
+              <UserCircle className="w-4 h-4" />
+              <span>حسابي</span>
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent dir="rtl" align="end" className="bg-white shadow-lg rounded-md border border-gray-200 text-gray-800">
+            <DropdownMenuItem asChild>
+              <Link to="/profile?tab=wishlist" className="flex items-center">
+                <Bookmark className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />
+                مكتبتي
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link to="/profile" className="flex items-center">
+                <User className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />
+                حسابي
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link to="/profile?tab=orders" className="flex items-center">
+                <ShoppingBag className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />
+                مشترياتي
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => handleFeatureClick('logout')} className="flex items-center text-red-600">
+              <LogOut className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />
+              تسجيل الخروج
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+    }
+    return (
+      <Link to="/login" className="flex items-center space-x-1 rtl:space-x-reverse hover:text-blue-200">
+        <UserCircle className="w-4 h-4" />
+        <span>تسجيل الدخول / إنشاء حساب</span>
+      </Link>
+    );
+  };
+
   const categoryItems = [
     { id: 'fiction', name: 'الخيال' },
     { id: 'nonfiction', name: 'غير الخيال' },
@@ -64,45 +110,7 @@ const Header = ({ handleFeatureClick, cartItemCount }) => {
         {/* Top Bar - Visible on all screens now, but adjusts layout */}
         <div className="flex items-center justify-between text-xs py-2 overflow-x-auto whitespace-nowrap pb-1 sm:pb-0"> {/* Removed hidden sm:flex */}
           <div className="flex items-center space-x-3 rtl:space-x-reverse flex-shrink-0"> {/* Added flex-shrink-0 */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button className="flex items-center space-x-1 rtl:space-x-reverse hover:text-blue-200">
-                  <UserCircle className="w-4 h-4" />
-                  <span>بروس وين</span>
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent dir="rtl" align="end" className="bg-white shadow-lg rounded-md border border-gray-200 text-gray-800">
-                <DropdownMenuItem asChild>
-                  <Link to="/profile?tab=wishlist" className="flex items-center">
-                    <Bookmark className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />
-                    مكتبتي
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link to="/profile" className="flex items-center">
-                    <User className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />
-                    حسابي
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link to="/profile?tab=orders" className="flex items-center">
-                    <ShoppingBag className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />
-                    مشترياتي
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => handleFeatureClick('logout')} className="flex items-center text-red-600">
-                  <LogOut className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />
-                  تسجيل الخروج
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link to="/login" className="flex items-center">
-                    <LogIn className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />
-                    تسجيل الدخول / إنشاء حساب
-                  </Link>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            {renderUserSection()}
             <span className="mx-2">|</span>
             <Link to="/ebooks" className="flex items-center space-x-1 rtl:space-x-reverse hover:text-blue-200">
               <Book className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- show dropdown menu only for logged-in users
- show login/register link when not logged in
- add logout behavior to header and profile

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686637165b18832a9ce863eb5523d4ec