### PR TITLE
Add subscription plan management

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -83,3 +83,22 @@ CREATE TABLE IF NOT EXISTS settings (
 );
 
 INSERT INTO settings (id, siteName) VALUES (1, 'Molhemoon') ON DUPLICATE KEY UPDATE siteName = VALUES(siteName);
+
+CREATE TABLE IF NOT EXISTS subscription_plans (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  price DECIMAL(10,2) NOT NULL,
+  duration INT NOT NULL,
+  description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  customer_id INT,
+  plan_id INT,
+  start_date DATETIME DEFAULT CURRENT_TIMESTAMP,
+  end_date DATETIME,
+  status VARCHAR(50) DEFAULT 'نشط',
+  FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE SET NULL,
+  FOREIGN KEY (plan_id) REFERENCES subscription_plans(id) ON DELETE SET NULL
+);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,6 +44,7 @@ const App = () => {
   });
   const [categoriesState, setCategoriesState] = useState([]);
   const [orders, setOrders] = useState(() => JSON.parse(localStorage.getItem('orders') || '[]'));
+  const [plans, setPlans] = useState(() => JSON.parse(localStorage.getItem('plans') || '[]'));
   const [siteSettingsState, setSiteSettingsState] = useState(() => {
     const stored = localStorage.getItem('siteSettings');
     return stored ? { ...initialSiteSettings, ...JSON.parse(stored) } : initialSiteSettings;
@@ -64,18 +65,20 @@ const App = () => {
     if (storedSettings) setSiteSettingsState(JSON.parse(storedSettings));
     (async () => {
       try {
-        const [b, a, c, s, o] = await Promise.all([
+        const [b, a, c, s, o, p] = await Promise.all([
           api.getBooks(),
           api.getAuthors(),
           api.getCategories(),
           api.getSettings(),
           api.getOrders(),
+          api.getPlans(),
         ]);
         setBooks(b);
         setAuthors(a);
         setCategoriesState(c);
         setSiteSettingsState(prev => ({ ...prev, ...s }));
         setOrders(o);
+        setPlans(p);
       } catch (err) {
         console.error('API fetch failed', err);
       }
@@ -106,6 +109,10 @@ const App = () => {
   useEffect(() => {
     localStorage.setItem('orders', JSON.stringify(orders));
   }, [orders]);
+
+  useEffect(() => {
+    localStorage.setItem('plans', JSON.stringify(plans));
+  }, [plans]);
 
   useEffect(() => {
     localStorage.setItem('siteSettings', JSON.stringify(siteSettingsState));
@@ -213,6 +220,7 @@ const App = () => {
                     customers={customers}
                     categories={categoriesState}
                     orders={orders}
+                    plans={plans}
                     dashboardSection={dashboardSection}
                     setDashboardSection={setDashboardSection}
                     handleFeatureClick={handleFeatureClick}
@@ -222,6 +230,7 @@ const App = () => {
                     setCustomers={setCustomers}
                     setCategories={setCategoriesState}
                     setOrders={setOrders}
+                    setPlans={setPlans}
                     siteSettings={siteSettingsState}
                     setSiteSettings={setSiteSettingsState}
                   />

--- a/src/components/SubscriptionDialog.jsx
+++ b/src/components/SubscriptionDialog.jsx
@@ -1,78 +1,82 @@
-import React from 'react'
-import * as DialogPrimitive from '@radix-ui/react-dialog' // تم إضافة هذا الاستيراد
-import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/ui/dialog.jsx'
-import { Button } from '@/components/ui/button.jsx'
-import { ChevronLeft, X } from 'lucide-react'; // تم إضافة هذا الاستيراد للأيقونات
+import React, { useEffect, useState } from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/ui/dialog.jsx';
+import { Button } from '@/components/ui/button.jsx';
+import { ChevronLeft, X } from 'lucide-react';
+import api from '@/lib/api.js';
+import { toast } from '@/components/ui/use-toast.js';
 
+const SubscriptionDialog = ({ open, onOpenChange, book, onAddToCart }) => {
+  const [plans, setPlans] = useState([]);
 
-const SubscriptionDialog = ({ open, onOpenChange, book, onAddToCart }) => (
-  <Dialog open={open} onOpenChange={onOpenChange}>
-    <DialogContent className="max-w-4xl space-y-6">
-      {/* Close Button at Top Right of the DialogContent */}
-      <DialogPrimitive.Close className='absolute top-3 left-3 text-gray-500 hover:text-gray-700'>
-        <X className='h-5 w-5' />
-      </DialogPrimitive.Close>
+  useEffect(() => {
+    (async () => {
+      try {
+        setPlans(await api.getPlans());
+      } catch (e) {
+        console.error(e);
+      }
+    })();
+  }, []);
 
-      {/* Header and Back Button */}
-      <div className="flex items-center text-blue-600 mb-4 sm:mb-6 cursor-pointer" onClick={() => onOpenChange(false)}>
-        <ChevronLeft className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />
-        <span className="text-sm font-medium">العودة إلى المتجر. قبل أن تحارب الكذب</span>
-      </div>
+  const handleSubscribe = async () => {
+    if (!plans.length) return;
+    try {
+      await api.addSubscription({ customer_id: 1, plan_id: plans[0].id });
+      toast({ title: 'تم الاشتراك بنجاح!' });
+      onOpenChange(false);
+    } catch (e) {
+      toast({ title: 'خطأ أثناء الاشتراك', variant: 'destructive' });
+    }
+  };
 
-      {/* Main Content Grid */}
-      <div className="grid md:grid-cols-10 gap-6">
-        {/* Sample Text Section */}
-        <div className="md:col-span-7 text-sm leading-relaxed space-y-4 rtl:text-right">
-          <h3 className="text-lg font-semibold mb-3">الفصل الأول</h3>
-          <h4 className="text-md font-medium text-gray-700 mb-4">رحلة إلى أسلوبك الفريد</h4>
-          <p data-edit-id="src/components/SubscriptionDialog.jsx:26:13">كان صباحًا منعشًا في بلدة بيلا في الماهامجا. حيث كانت الشوارع تعج بالنشاط بين بين الحشد الذي لايعد ولا يحصى. الناس فقط يفضلون منطقة الأليفينو في براغاشثة الغربية في اختيار الإكسيليونغا، بل يفضلن مثالة القادمة التي لا تذكر لم يكن يمكن لأحد قادمًا. لقد كان رمزًا للآزانغا، ويوشافتا، وصديقًا لكل من يكتشفون داته الحقيقية من خلال المؤمنة.</p>
-          <p data-edit-id="src/components/SubscriptionDialog.jsx:27:13">اليوم، كان كل شيء في مهمة. كان مهرجان "الصحوة اللغوية" السنوي في المدينة يقترب بسرعة، وقد اختير ليمنا لتوجيه مجموعة من الأفراد المتحمسين المستعدين لخوض رحلتهم لاكتشاف المفاهيم الفريدة. بوضعية تعابير يتوقف في السماء ويقدم ملاحظاته الموثوقة. أطلقوا لقاء قادته الجدة.</p>
-          <h5 className="font-semibold text-base mb-2">التجمع</h5>
-          <p data-edit-id="src/components/SubscriptionDialog.jsx:29:13">كان صباحًا منعشًا في بلدة بيلا في الماهامجا. حيث كانت الشوارع تعج بالنشاط بين بين الحشد الذي لايعد ولا يحصى. الناس فقط يفضلون منطقة الأليفينو في براغاشثة الغربية في اختيار الإكسيليونغا، بل يفضلن مثالة القادمة التي لا تذكر لم يكن يمكن لأحد قادمًا. لقد كان رمزًا للآزانغا، ويوشافتا، وصديقًا لكل من يكتشفون داته الحقيقية من خلال المؤمنة.</p>
-          <p data-edit-id="src/components/SubscriptionDialog.jsx:30:13">اليوم، كان كل شيء في مهمة. كان مهرجان "الصحوة اللغوية" السنوي في المدينة يقترب بسرعة، وقد اختير ليمنا لتوجيه مجموعة من الأفراد المتحمسين المستعدين لخوض رحلتهم لاكتشاف المفاهيم الفريدة. بوضعية تعابير يتوقف في السماء ويقدم ملاحظاته الموثوقة. أطلقوا لقاء قادته الجدة.</p>
-          <p data-edit-id="src/components/SubscriptionDialog.jsx:31:13">اليوم، كان كل شيء في مهمة. كان مهرجان "الصحوة اللغوية" السنوي في المدينة يقترب بسرعة، وقد اختير ليمنا لتوجيه مجموعة من الأفراد المتحمسين المستعدين لخوض رحلتهم لاكتشاف المفاهيم الفريدة. بوضعية تعابير يتوقف في السماء ويقدم ملاحظاته الموثوقة. أطلقوا لقاء قادته الجدة.</p>
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl space-y-6">
+        <DialogPrimitive.Close className="absolute top-3 left-3 text-gray-500 hover:text-gray-700">
+          <X className="h-5 w-5" />
+        </DialogPrimitive.Close>
+        <div className="flex items-center text-blue-600 mb-4 cursor-pointer" onClick={() => onOpenChange(false)}>
+          <ChevronLeft className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />
+          <span className="text-sm font-medium">العودة إلى المتجر</span>
         </div>
-
-        {/* Book Info and Subscription Prompt Section */}
-        <div className="md:col-span-3 space-y-4">
-          <div className="bg-white rounded-lg shadow p-4 space-y-4">
-            <div className="flex justify-between items-end text-sm">
-              <div>
-                {book?.originalPrice && (
-                  <span className="line-through text-red-500 mr-2 rtl:ml-2 rtl:mr-0">{book.originalPrice.toFixed(2)} د.إ</span>
-                )}
-                <div className="text-2xl font-bold text-blue-600">{book?.price.toFixed(2)} د.إ</div>
+        <div className="grid md:grid-cols-2 gap-6">
+          <div className="space-y-4 text-sm rtl:text-right">
+            <h3 className="text-lg font-semibold mb-3">الفصل الأول</h3>
+            <p>{book?.description}</p>
+          </div>
+          <div className="space-y-4">
+            <div className="bg-white rounded-lg shadow p-4 space-y-4">
+              <div className="flex justify-between items-end text-sm">
+                <div>
+                  {book?.originalPrice && (
+                    <span className="line-through text-red-500 ml-2">{book.originalPrice.toFixed(2)} د.إ</span>
+                  )}
+                  <div className="text-2xl font-bold text-blue-600">{book?.price.toFixed(2)} د.إ</div>
+                </div>
               </div>
-              {book?.originalPrice && (
-                <div className="text-green-600">وفر {(book.originalPrice - book.price).toFixed(2)} د.إ</div>
+              <Button onClick={onAddToCart} className="w-full bg-blue-600 hover:bg-blue-700 h-9 text-white">
+                أضف إلى السلة
+              </Button>
+            </div>
+            <hr />
+            <div className="space-y-2 text-center">
+              <DialogTitle className="text-lg font-bold">استمتع بقراءة واستماع بلا حدود</DialogTitle>
+              <DialogDescription>لمواصلة القراءة والاستماع – تحتاج إلى باقة اشتراكك.</DialogDescription>
+              {plans.length > 0 && (
+                <div className="text-sm">
+                  <p>{plans[0].name} - {plans[0].price} د.إ / {plans[0].duration} يوم</p>
+                </div>
               )}
+              <Button className="w-full bg-blue-600 hover:bg-blue-700 text-white" onClick={handleSubscribe}>
+                اشترك الآن
+              </Button>
             </div>
-            <Button onClick={onAddToCart} className="w-full bg-blue-600 hover:bg-blue-700 h-9 text-white">
-              <i className="fa-solid fa-cart-plus w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />أضف إلى السلة
-            </Button>
-            <Button variant="secondary" className="w-full mb-3">اشتري الان بنقرة واحدة</Button>
-            <div className="flex justify-around text-sm text-gray-600">
-              <Button variant="ghost" size="sm" className="px-2"><i className="fa-solid fa-comment ml-2 rtl:mr-2 rtl:ml-0" />دردش</Button>
-              <Button variant="ghost" size="sm" className="px-2"><i className="fa-solid fa-heart ml-2 rtl:mr-2 rtl:ml-0" />قائمة الرغبات</Button>
-              <Button variant="ghost" size="sm" className="px-2"><i className="fa-solid fa-share ml-2 rtl:mr-2 rtl:ml-0" />مشاركة</Button>
-            </div>
-          </div>
-          <hr />
-          <img data-edit-id="src/components/SubscriptionDialog.jsx:70:11" alt={`غلاف كتاب ${book?.title}`} className="w-full h-40 object-cover rounded" src="/Darmolhimon_ Read Sample.png" />
-          <div className="space-y-2 text-center">
-            <DialogTitle data-edit-id="src/components/SubscriptionDialog.jsx:72:13" className="text-lg font-bold">استمتع بقراءة واستماع بلا حدود</DialogTitle>
-            <DialogDescription data-edit-id="src/components/SubscriptionDialog.jsx:73:13">لمواصلة القراءة والاستماع – تحتاج إلى باقة اشتراكك.</DialogDescription>
-            <ul className="space-y-1 text-sm rtl:text-right">
-              <li data-edit-id="src/components/SubscriptionDialog.jsx:75:15"><i className="fa-solid fa-book-open ml-2 rtl:mr-2 rtl:ml-0" />كتب إلكترونية وصوتية بلا حدود</li>
-              <li data-edit-id="src/components/SubscriptionDialog.jsx:76:15"><i className="fa-solid fa-folder-open ml-2 rtl:mr-2 rtl:ml-0" />وصول إلى مجموعات مختارة</li>
-              <li data-edit-id="src/components/SubscriptionDialog.jsx:77:15"><i className="fa-solid fa-download ml-2 rtl:mr-2 rtl:ml-0" />تنزيل الكتب دون اتصال</li>
-            </ul>
-            <Button className="w-full bg-blue-600 hover:bg-blue-700 text-white">اشترك الآن</Button>
           </div>
         </div>
-      </div>
-    </DialogContent>
-  </Dialog>
-)
+      </DialogContent>
+    </Dialog>
+  );
+};
 
-export default SubscriptionDialog
+export default SubscriptionDialog;

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -43,6 +43,13 @@ export const api = {
 
   getSettings: () => request('/api/settings'),
   updateSettings: (data) => request('/api/settings', { method: 'PUT', body: JSON.stringify(data) }),
+  getPlans: () => request('/api/plans'),
+  addPlan: (data) => request('/api/plans', { method: 'POST', body: JSON.stringify(data) }),
+  updatePlan: (id, data) => request(`/api/plans/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  deletePlan: (id) => request(`/api/plans/${id}`, { method: 'DELETE' }),
+
+  getSubscriptions: () => request('/api/subscriptions'),
+  addSubscription: (data) => request('/api/subscriptions', { method: 'POST', body: JSON.stringify(data) }),
 };
 
 export default api;


### PR DESCRIPTION
## Summary
- create tables for subscription plans and user subscriptions
- implement subscription API routes
- expose plan functions in `api.js`
- manage plans in React app state
- add plan management section to Dashboard
- update subscription dialog to subscribe via API

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866388c44dc832a821acc9b67ede402