### PR TITLE
Add book type and sample reading/listening pages

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -27,6 +27,8 @@ CREATE TABLE IF NOT EXISTS books (
   pages INT,
   format VARCHAR(50),
   cover_image VARCHAR(255),
+  type ENUM('ebook','audio','both') DEFAULT 'ebook',
+  sample_audio VARCHAR(255),
   FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL,
   FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL
 );

--- a/backend/server.js
+++ b/backend/server.js
@@ -27,8 +27,8 @@ app.get('/api/books', async (_req, res) => {
 app.post('/api/books', async (req, res) => {
   const data = req.body;
   const [result] = await pool.execute(
-    'INSERT INTO books (title, author_id, category_id, price, original_price, rating, reviews, description, isbn, publisher, publish_date, pages, format, cover_image) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)',
-    [data.title, data.author_id, data.category_id, data.price, data.original_price, data.rating, data.reviews, data.description, data.isbn, data.publisher, data.publish_date, data.pages, data.format, data.cover_image]
+    'INSERT INTO books (title, author_id, category_id, price, original_price, rating, reviews, description, isbn, publisher, publish_date, pages, format, cover_image, type, sample_audio) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)',
+    [data.title, data.authorId, data.categoryId, data.price, data.originalPrice, data.rating, data.reviews, data.description, data.isbn, data.publisher, data.publishDate, data.pages, data.format, data.coverImage, data.type, data.sampleAudio]
   );
   const [rows] = await pool.query('SELECT * FROM books WHERE id=?', [result.insertId]);
   res.status(201).json(rows[0]);
@@ -37,7 +37,25 @@ app.post('/api/books', async (req, res) => {
 app.put('/api/books/:id', async (req, res) => {
   const id = req.params.id;
   const data = req.body;
-  await pool.query('UPDATE books SET ? WHERE id=?', [data, id]);
+  const mapped = {
+    title: data.title,
+    author_id: data.authorId,
+    category_id: data.categoryId,
+    price: data.price,
+    original_price: data.originalPrice,
+    rating: data.rating,
+    reviews: data.reviews,
+    description: data.description,
+    isbn: data.isbn,
+    publisher: data.publisher,
+    publish_date: data.publishDate,
+    pages: data.pages,
+    format: data.format,
+    cover_image: data.coverImage,
+    type: data.type,
+    sample_audio: data.sampleAudio,
+  };
+  await pool.query('UPDATE books SET ? WHERE id=?', [mapped, id]);
   const [rows] = await pool.query('SELECT * FROM books WHERE id=?', [id]);
   res.json(rows[0]);
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,8 @@ import UserProfilePage from '@/pages/UserProfilePage.jsx';
 import NotFoundPage from '@/pages/NotFoundPage.jsx';
 import AudiobookPage from '@/pages/AudiobookPage.jsx';
 import EbookPage from '@/pages/EbookPage.jsx';
+import ReadSamplePage from '@/pages/ReadSamplePage.jsx';
+import ListenSamplePage from '@/pages/ListenSamplePage.jsx';
 import AddToCartDialog from '@/components/AddToCartDialog.jsx';
 
 import { categories as initialCategories, books as initialBooks, authors as initialAuthors, sellers as initialSellers, customers as initialCustomers, dashboardStats, footerLinks, featuresData, heroSlides, recentSearchBooks, bestsellerBooks, siteSettings as initialSiteSettings } from '@/data/siteData.js';
@@ -281,6 +283,8 @@ const App = () => {
               <Route path="/profile" element={<MainLayout><PageLayout><UserProfilePage handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
               <Route path="/ebooks" element={<MainLayout><PageLayout><EbookPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} wishlist={wishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
               <Route path="/audiobooks" element={<MainLayout><PageLayout><AudiobookPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} wishlist={wishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
+              <Route path="/read/:id" element={<MainLayout><PageLayout><ReadSamplePage books={books} /></PageLayout></MainLayout>} />
+              <Route path="/listen/:id" element={<MainLayout><PageLayout><ListenSamplePage books={books} /></PageLayout></MainLayout>} />
               <Route path="*" element={<MainLayout><PageLayout><NotFoundPage /></PageLayout></MainLayout>} />
             </Routes>
         </AnimatePresence>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1047,6 +1047,7 @@ const BookForm = ({ book, onSubmit, onCancel, authors, categories }) => {
     description: '',
     imgPlaceholder: '',
     type: '',
+    sampleAudio: '',
     tags: '',
     coverImage: '',
     ...book
@@ -1110,8 +1111,23 @@ const BookForm = ({ book, onSubmit, onCancel, authors, categories }) => {
             </select>
           </div>
           <div>
-            <Label htmlFor="type">النوع</Label>
-            <Input id="type" name="type" value={formData.type} onChange={handleChange} />
+            <Label htmlFor="type">نوع الكتاب</Label>
+            <select
+              id="type"
+              name="type"
+              value={formData.type}
+              onChange={handleChange}
+              className="w-full p-2 border border-gray-300 rounded-md"
+            >
+              <option value="">اختر نوع الكتاب</option>
+              <option value="ebook">كتاب إلكتروني</option>
+              <option value="audio">كتاب صوتي</option>
+              <option value="both">كلاهما</option>
+            </select>
+          </div>
+          <div>
+            <Label htmlFor="sampleAudio">رابط عينة صوتية</Label>
+            <Input id="sampleAudio" name="sampleAudio" value={formData.sampleAudio} onChange={handleChange} />
           </div>
           <div>
             <Label htmlFor="tags">الوسوم</Label>

--- a/src/data/siteData.js
+++ b/src/data/siteData.js
@@ -67,7 +67,8 @@ export const books = [
     pages: 120,
     format: 'غلاف ورقي',
     coverImage: '',
-    type: '',
+    type: 'both',
+    sampleAudio: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',
     tags: ''
   },
   {

--- a/src/pages/BookDetailsPage.jsx
+++ b/src/pages/BookDetailsPage.jsx
@@ -2,9 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button.jsx';
-import SubscriptionDialog from '@/components/SubscriptionDialog.jsx';
 import { Star, Heart, ShoppingCart, Share2, BookOpenText, Headphones, ChevronDown } from 'lucide-react';
-import AudioSamplePlayer from '@/components/AudioSamplePlayer.jsx';
 import { BookCard } from '@/components/FlashSaleSection.jsx';
 import YouMayAlsoLikeSection from '@/components/YouMayAlsoLikeSection.jsx';
 import { toast } from "@/components/ui/use-toast.js";
@@ -16,8 +14,6 @@ const BookDetailsPage = ({ books, authors, handleAddToCart, handleToggleWishlist
   const [activeTab, setActiveTab] = useState('details');
   const [showFullDescription, setShowFullDescription] = useState(false);
   const [isInWishlist, setIsInWishlist] = useState(false);
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [audioOpen, setAudioOpen] = useState(false);
 
   useEffect(() => {
     const currentBook = books.find(b => b.id.toString() === id);
@@ -84,8 +80,16 @@ const BookDetailsPage = ({ books, authors, handleAddToCart, handleToggleWishlist
             </span>
           </div>
           <div className="flex flex-col space-y-2 w-80">
-            <Button variant="ghost" onClick={() => setDialogOpen(true)} className="w-full bg-purple-700/10 text-purple-700 hover:bg-purple-700/20"><BookOpenText className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0 text-purple-700" />اقرأ عينة</Button>
-            <Button variant="ghost" onClick={() => setAudioOpen(true)} className="w-full bg-purple-700/10 text-purple-700 hover:bg-purple-700/20"><Headphones className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0 text-purple-700" />عينة صوتية</Button>
+            <Link to={`/read/${book.id}`} className="w-full">
+              <Button variant="ghost" className="w-full bg-purple-700/10 text-purple-700 hover:bg-purple-700/20">
+                <BookOpenText className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0 text-purple-700" />اقرأ عينة
+              </Button>
+            </Link>
+            <Link to={`/listen/${book.id}`} className="w-full">
+              <Button variant="ghost" className="w-full bg-purple-700/10 text-purple-700 hover:bg-purple-700/20">
+                <Headphones className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0 text-purple-700" />عينة صوتية
+              </Button>
+            </Link>
           </div>
         </motion.div>
 
@@ -301,8 +305,6 @@ const BookDetailsPage = ({ books, authors, handleAddToCart, handleToggleWishlist
           authors={authors}
         />
       )}
-      <SubscriptionDialog open={dialogOpen} onOpenChange={setDialogOpen} book={book} onAddToCart={onAddToCart} />
-      {audioOpen && <AudioSamplePlayer book={book} onClose={() => setAudioOpen(false)} />}
     </div>
   );
 };

--- a/src/pages/ListenSamplePage.jsx
+++ b/src/pages/ListenSamplePage.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+const ListenSamplePage = ({ books }) => {
+  const { id } = useParams();
+  const book = books.find(b => b.id.toString() === id);
+  if (!book) {
+    return <div className="container mx-auto px-4 py-8 text-center">جاري التحميل...</div>;
+  }
+  const audioSrc = book.sampleAudio || 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3';
+  return (
+    <div className="container mx-auto px-4 py-8 text-center">
+      <Link to={`/book/${id}`} className="text-blue-600 hover:underline block mb-4 text-right rtl:text-right">العودة لتفاصيل الكتاب</Link>
+      <h1 className="text-2xl font-bold mb-4 rtl:text-right">{book.title}</h1>
+      <audio controls src={audioSrc} className="w-full" />
+    </div>
+  );
+};
+
+export default ListenSamplePage;

--- a/src/pages/ReadSamplePage.jsx
+++ b/src/pages/ReadSamplePage.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+const ReadSamplePage = ({ books }) => {
+  const { id } = useParams();
+  const book = books.find(b => b.id.toString() === id);
+  if (!book) {
+    return <div className="container mx-auto px-4 py-8 text-center">جاري التحميل...</div>;
+  }
+  return (
+    <div className="container mx-auto px-4 py-8 rtl:text-right">
+      <Link to={`/book/${id}`} className="text-blue-600 hover:underline block mb-4">العودة لتفاصيل الكتاب</Link>
+      <h1 className="text-2xl font-bold mb-4">{book.title}</h1>
+      <p className="whitespace-pre-line leading-loose text-gray-800">
+        {book.description || 'لا توجد عينة نصية متاحة.'}
+      </p>
+    </div>
+  );
+};
+
+export default ReadSamplePage;


### PR DESCRIPTION
## Summary
- allow storing book type and audio sample
- support book type and sample inputs in dashboard
- create pages to read or listen to book samples
- link new sample pages from book details
- expose new routes for reading and listening

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686643e2be40832a94b95ba2183dda2b