### PR TITLE
Display site settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -130,6 +130,12 @@ const App = () => {
     localStorage.setItem('siteSettings', JSON.stringify(siteSettingsState));
   }, [siteSettingsState]);
 
+  useEffect(() => {
+    if (siteSettingsState.siteName) {
+      document.title = siteSettingsState.siteName;
+    }
+  }, [siteSettingsState.siteName]);
+
   const handleAddToCart = (book) => {
     setCart((prevCart) => {
       const existingBook = prevCart.find(item => item.id === book.id);
@@ -210,7 +216,7 @@ const App = () => {
     );
   };
   
-  const MainLayout = ({ children }) => (
+  const MainLayout = ({ children, siteSettings }) => (
     <div className="min-h-screen bg-slate-100 text-gray-800">
       <Header
         handleFeatureClick={handleFeatureClick}
@@ -218,9 +224,14 @@ const App = () => {
         isCustomerLoggedIn={isCustomerLoggedIn}
         books={books}
         categories={categoriesState}
+        siteSettings={siteSettings}
       />
       {children}
-      <Footer footerLinks={footerLinks} handleFeatureClick={handleFeatureClick} />
+      <Footer
+        footerLinks={footerLinks}
+        handleFeatureClick={handleFeatureClick}
+        siteSettings={siteSettings}
+      />
     </div>
   );
 
@@ -270,22 +281,22 @@ const App = () => {
                 isCustomerLoggedIn ? (
                   <Navigate to="/profile" />
                 ) : (
-                  <MainLayout><PageLayout><AuthPage onLogin={() => setIsCustomerLoggedIn(true)} /></PageLayout></MainLayout>
+                  <MainLayout siteSettings={siteSettingsState}><PageLayout><AuthPage onLogin={() => setIsCustomerLoggedIn(true)} /></PageLayout></MainLayout>
                 )
               }
             />
-            <Route path="/" element={<MainLayout><PageLayout><HomePage books={books} authors={authors} heroSlides={heroSlides} categories={categoriesState} recentSearchBooks={recentSearchBooks} bestsellerBooks={bestsellerBooks} featuresData={featuresData} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
-              <Route path="/book/:id" element={<MainLayout><PageLayout><BookDetailsPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} /></PageLayout></MainLayout>} />
-              <Route path="/author/:id" element={<MainLayout><PageLayout><AuthorPage authors={authors} books={books} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} /></PageLayout></MainLayout>} />
-              <Route path="/category/:categoryId" element={<MainLayout><PageLayout><CategoryPage books={books} categories={categoriesState} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} /></PageLayout></MainLayout>} />
-              <Route path="/cart" element={<MainLayout><PageLayout><CartPage cart={cart} handleRemoveFromCart={handleRemoveFromCart} handleUpdateQuantity={handleUpdateQuantity} /></PageLayout></MainLayout>} />
-              <Route path="/checkout" element={<MainLayout><PageLayout><CheckoutPage cart={cart} setCart={setCart} setOrders={setOrders} /></PageLayout></MainLayout>} />
-              <Route path="/profile" element={<MainLayout><PageLayout><UserProfilePage handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
-              <Route path="/ebooks" element={<MainLayout><PageLayout><EbookPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} wishlist={wishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
-              <Route path="/audiobooks" element={<MainLayout><PageLayout><AudiobookPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} wishlist={wishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
-              <Route path="/read/:id" element={<MainLayout><PageLayout><ReadSamplePage books={books} /></PageLayout></MainLayout>} />
-              <Route path="/listen/:id" element={<MainLayout><PageLayout><ListenSamplePage books={books} /></PageLayout></MainLayout>} />
-              <Route path="*" element={<MainLayout><PageLayout><NotFoundPage /></PageLayout></MainLayout>} />
+            <Route path="/" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><HomePage books={books} authors={authors} heroSlides={heroSlides} categories={categoriesState} recentSearchBooks={recentSearchBooks} bestsellerBooks={bestsellerBooks} featuresData={featuresData} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
+              <Route path="/book/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><BookDetailsPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} /></PageLayout></MainLayout>} />
+              <Route path="/author/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><AuthorPage authors={authors} books={books} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} /></PageLayout></MainLayout>} />
+              <Route path="/category/:categoryId" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><CategoryPage books={books} categories={categoriesState} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} /></PageLayout></MainLayout>} />
+              <Route path="/cart" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><CartPage cart={cart} handleRemoveFromCart={handleRemoveFromCart} handleUpdateQuantity={handleUpdateQuantity} /></PageLayout></MainLayout>} />
+              <Route path="/checkout" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><CheckoutPage cart={cart} setCart={setCart} setOrders={setOrders} /></PageLayout></MainLayout>} />
+              <Route path="/profile" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><UserProfilePage handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
+              <Route path="/ebooks" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><EbookPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} wishlist={wishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
+              <Route path="/audiobooks" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><AudiobookPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} wishlist={wishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
+              <Route path="/read/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><ReadSamplePage books={books} /></PageLayout></MainLayout>} />
+              <Route path="/listen/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><ListenSamplePage books={books} /></PageLayout></MainLayout>} />
+              <Route path="*" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><NotFoundPage /></PageLayout></MainLayout>} />
             </Routes>
         </AnimatePresence>
         <Toaster />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -5,7 +5,7 @@ import { Facebook, Twitter, Instagram, Linkedin, Youtube, MessageSquare } from '
 import { Button } from '@/components/ui/button.jsx';
 import NewsletterSection from '@/components/NewsletterSection.jsx';
 
-const Footer = ({ footerLinks, handleFeatureClick }) => {
+const Footer = ({ footerLinks, handleFeatureClick, siteSettings = {} }) => {
   return (
     <>
     <NewsletterSection handleFeatureClick={handleFeatureClick} />
@@ -46,6 +46,15 @@ const Footer = ({ footerLinks, handleFeatureClick }) => {
                     App Store
                 </button>
             </div>
+            {siteSettings.contactEmail && (
+              <p className="text-[11px] text-white mt-4">{siteSettings.contactEmail}</p>
+            )}
+            {siteSettings.contactPhone && (
+              <p className="text-[11px] text-white">{siteSettings.contactPhone}</p>
+            )}
+            {siteSettings.address && (
+              <p className="text-[11px] text-white">{siteSettings.address}</p>
+            )}
           </div>
 
           {footerLinks.map((section, index) => (
@@ -78,7 +87,7 @@ const Footer = ({ footerLinks, handleFeatureClick }) => {
         </div>
 
         <div className="border-t border-slate-700/50 pt-5 sm:pt-6 flex flex-col sm:flex-row justify-between items-center text-[10px] sm:text-xs text-white">
-          <p>جميع الحقوق محفوظة © {new Date().getFullYear()} ملهمون</p>
+          <p>جميع الحقوق محفوظة © {new Date().getFullYear()} {siteSettings.siteName || 'ملهمون'}</p>
           <div className="flex space-x-2.5 sm:space-x-3 rtl:space-x-reverse mt-2 sm:mt-0">
             <a href="#" className="hover:text-blue-200" onClick={(e) => {e.preventDefault(); handleFeatureClick('privacy-policy')}}>سياسة الخصوصية</a>
             <a href="#" className="hover:text-blue-200" onClick={(e) => {e.preventDefault(); handleFeatureClick('terms-of-use')}}>شروط الاستخدام</a>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -21,7 +21,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator, DropdownMenuLabel } from '@/components/ui/dropdown-menu.jsx';
 
-const Header = ({ handleFeatureClick, cartItemCount, isCustomerLoggedIn, books = [], categories = [] }) => {
+const Header = ({ handleFeatureClick, cartItemCount, isCustomerLoggedIn, books = [], categories = [], siteSettings = {} }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [suggestions, setSuggestions] = useState([]);
 
@@ -213,8 +213,12 @@ const Header = ({ handleFeatureClick, cartItemCount, isCustomerLoggedIn, books =
               whileHover={{ scale: 1.05 }}
             >
               <Link to="/" className="flex items-center">
-                <img  alt="شعار ملهمون" className="h-10 w-auto mr-2 rtl:ml-2 rtl:mr-0" src="https://darmolhimon.com/wp-content/uploads/2021/07/Dar.png" />
-               
+                <img
+                  alt={siteSettings.siteName || 'شعار ملهمون'}
+                  className="h-10 w-auto mr-2 rtl:ml-2 rtl:mr-0"
+                  src="https://darmolhimon.com/wp-content/uploads/2021/07/Dar.png"
+                />
+                <span className="font-semibold text-lg">{siteSettings.siteName || 'ملهمون'}</span>
               </Link>
             </motion.div>
           </div>


### PR DESCRIPTION
## Summary
- expose `siteSettings` in `MainLayout`
- show site name and contact info in the header/footer
- update page title dynamically using site settings

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686646938a70832aa6265acc4d76d1db