### PR TITLE
Add icon dropdown for categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ Set `GOOGLE_MERCHANT_ID` and `GOOGLE_API_KEY` in your `.env` file to enable impo
 ## Notes
 - CRUD actions in the dashboard now communicate with the backend using the provided API routes.
 - If you need to build the project for production, run `npm run build` (requires installed dependencies).
+- Category management forms now include a dropdown to select an icon from the `lucide-react` library.

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -25,6 +25,7 @@ import {
   Image,
   Zap
 } from 'lucide-react';
+import * as AllIcons from 'lucide-react';
 import { Input } from '@/components/ui/input.jsx';
 import { Label } from '@/components/ui/label.jsx';
 import { Textarea } from '@/components/ui/textarea.jsx';
@@ -228,6 +229,7 @@ const DashboardAuthors = ({ authors, setAuthors }) => {
 
 const CategoryForm = ({ category, onSubmit, onCancel }) => {
   const [formData, setFormData] = useState({ id: '', name: '', icon: '', ...category });
+  const iconNames = React.useMemo(() => Object.keys(AllIcons).filter((name) => /^[A-Z]/.test(name)).sort(), []);
 
   const handleChange = (e) => setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
 
@@ -247,7 +249,19 @@ const CategoryForm = ({ category, onSubmit, onCancel }) => {
         </div>
         <div>
           <Label htmlFor="icon">الأيقونة</Label>
-          <Input id="icon" name="icon" value={formData.icon} onChange={handleChange} required />
+          <select
+            id="icon"
+            name="icon"
+            value={formData.icon}
+            onChange={handleChange}
+            className="w-full p-2 border border-gray-300 rounded-md"
+            required
+          >
+            <option value="">اختر أيقونة</option>
+            {iconNames.map((name) => (
+              <option key={name} value={name}>{name}</option>
+            ))}
+          </select>
         </div>
         <div className="flex justify-end space-x-3 rtl:space-x-reverse">
           <Button type="button" variant="outline" onClick={onCancel}>إلغاء</Button>


### PR DESCRIPTION
## Summary
- enable icon selection from a dropdown in dashboard category form
- expose all Lucide icons for easy choice
- document the new icon dropdown in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665794ca88832ab244d532635ab492