### PR TITLE
Add currency options with flags

### DIFF
--- a/src/components/FormattedPrice.jsx
+++ b/src/components/FormattedPrice.jsx
@@ -3,13 +3,13 @@ import { useCurrency, getPriceForCurrency } from '@/lib/currencyContext.jsx';
 
 const FormattedPrice = ({ book, value }) => {
   const { currency } = useCurrency();
-  const Icon = currency.icon;
+  const { flag, name } = currency;
   const priceValue = value !== undefined ? value : getPriceForCurrency(book, currency.code);
   const amount = Number(priceValue || 0).toFixed(2);
   return (
     <span className="inline-flex items-center gap-0.5">
       {amount}
-      <Icon className="w-3.5 h-3.5" />
+      <img src={flag} alt={`علم ${name}`} className="w-3.5 h-3.5 object-contain" />
     </span>
   );
 };

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -174,20 +174,18 @@ const Header = ({ handleFeatureClick, cartItemCount, isCustomerLoggedIn, books =
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" className="text-xs text-white hover:bg-blue-600 hover:text-white p-1 h-auto">
-                  <img  alt="علم الإمارات العربية المتحدة" className="w-5 h-3 ml-2 object-contain rtl:mr-2 rtl:ml-0" src="https://darmolhimon.com/wp-content/uploads/2025/06/united-arab-emirates-svgrepo-com.svg" />
-                  الإمارات العربية المتحدة | الإمارات العربية المتحدة
+                  <img alt={`علم ${currency.name}`} className="w-5 h-3 ml-2 object-contain rtl:mr-2 rtl:ml-0" src={currency.flag} />
+                  {currency.name}
                   <ChevronDown className="w-3 h-3 mr-2 rtl:ml-2 rtl:mr-0" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="bg-white shadow-lg rounded-md border border-gray-200 text-gray-800">
-                <DropdownMenuItem onClick={() => handleFeatureClick('change-country-ksa')} className="hover:bg-blue-50 flex items-center">
-                  <img  alt="علم المملكة العربية السعودية" className="w-5 h-3 ml-2 object-contain rtl:mr-2 rtl:ml-0" src="https://cdn.countryflags.com/thumbs/saudi-arabia/flag-round-250.png" />
-                  المملكة العربية السعودية | KSA
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => handleFeatureClick('change-country-eg')} className="hover:bg-blue-50 flex items-center">
-                  <img  alt="علم مصر" className="w-5 h-3 ml-2 object-contain rtl:mr-2 rtl:ml-0" src="https://vectorflags.s3.amazonaws.com/flags/eg-circle-01.png" />
-                  مصر | EG
-                </DropdownMenuItem>
+                {currencies.map(c => (
+                  <DropdownMenuItem key={c.code} onClick={() => setCurrency(c)} className="hover:bg-blue-50 flex items-center">
+                    <img alt={`علم ${c.name}`} className="w-5 h-3 ml-2 object-contain rtl:mr-2 rtl:ml-0" src={c.flag} />
+                    {c.name} | {c.code}
+                  </DropdownMenuItem>
+                ))}
               </DropdownMenuContent>
             </DropdownMenu>
             <DropdownMenu>
@@ -310,21 +308,6 @@ const Header = ({ handleFeatureClick, cartItemCount, isCustomerLoggedIn, books =
               </Link>
             </Button>
 
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="text-white hover:text-blue-200 w-10 h-10">
-                  {React.createElement(currency.icon, { className: 'w-5 h-5' })}
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start">
-                {currencies.map(c => (
-                  <DropdownMenuItem key={c.code} onClick={() => setCurrency(c)} className="flex items-center gap-2 rtl:space-x-reverse">
-                    {React.createElement(c.icon, { className: 'w-4 h-4' })}
-                    <span>{c.code}</span>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
 
             <Button asChild variant="ghost" size="icon" className="relative text-white hover:text-blue-200 w-10 h-10">
               <Link to="/cart">

--- a/src/lib/currencyContext.jsx
+++ b/src/lib/currencyContext.jsx
@@ -1,12 +1,31 @@
 import React, { createContext, useContext, useState } from 'react';
-import { DollarSign, Euro, PoundSterling, Coins, Bitcoin } from 'lucide-react';
 
 export const currencies = [
-  { code: 'AED', icon: Coins },
-  { code: 'USD', icon: DollarSign },
-  { code: 'EUR', icon: Euro },
-  { code: 'GBP', icon: PoundSterling },
-  { code: 'BTC', icon: Bitcoin },
+  {
+    code: 'AED',
+    name: 'الإمارات العربية المتحدة',
+    flag: 'https://cdn.countryflags.com/thumbs/united-arab-emirates/flag-round-250.png',
+  },
+  {
+    code: 'USD',
+    name: 'دولار أمريكي',
+    flag: 'https://cdn.countryflags.com/thumbs/united-states-of-america/flag-round-250.png',
+  },
+  {
+    code: 'EUR',
+    name: 'يورو',
+    flag: 'https://cdn.countryflags.com/thumbs/european-union/flag-round-250.png',
+  },
+  {
+    code: 'GBP',
+    name: 'جنيه إسترليني',
+    flag: 'https://cdn.countryflags.com/thumbs/united-kingdom/flag-round-250.png',
+  },
+  {
+    code: 'BTC',
+    name: 'بيتكوين',
+    flag: 'https://cryptologos.cc/logos/bitcoin-btc-logo.png?width=32',
+  },
 ];
 
 const CurrencyContext = createContext({ currency: currencies[0], setCurrency: () => {}, currencies });


### PR DESCRIPTION
## Summary
- support currency name and flag in `currencyContext`
- switch currencies from the country dropdown
- show currency flag next to prices
- simplify book form to handle dynamic currencies

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686658d35114832abc3ab34e04bdd6c9