### PR TITLE
Add conditional book type fields

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -29,6 +29,9 @@ CREATE TABLE IF NOT EXISTS books (
   cover_image VARCHAR(255),
   type ENUM('physical','ebook','audio') DEFAULT 'physical',
   sample_audio VARCHAR(255),
+  delivery_method VARCHAR(255),
+  ebook_file VARCHAR(255),
+  audio_file VARCHAR(255),
   FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL,
   FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL
 );

--- a/backend/server.js
+++ b/backend/server.js
@@ -27,8 +27,28 @@ app.get('/api/books', async (_req, res) => {
 app.post('/api/books', async (req, res) => {
   const data = req.body;
   const [result] = await pool.execute(
-    'INSERT INTO books (title, author_id, category_id, price, original_price, rating, reviews, description, isbn, publisher, publish_date, pages, format, cover_image, type, sample_audio) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)',
-    [data.title, data.authorId, data.categoryId, data.price, data.originalPrice, 0, 0, data.description, data.isbn, data.publisher, data.publishDate, data.pages, data.format, data.coverImage, data.type, data.sampleAudio]
+    'INSERT INTO books (title, author_id, category_id, price, original_price, rating, reviews, description, isbn, publisher, publish_date, pages, format, cover_image, type, sample_audio, delivery_method, ebook_file, audio_file) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)',
+    [
+      data.title,
+      data.authorId,
+      data.categoryId,
+      data.price,
+      data.originalPrice,
+      0,
+      0,
+      data.description,
+      data.isbn,
+      data.publisher,
+      data.publishDate,
+      data.pages,
+      data.format,
+      data.coverImage,
+      data.type,
+      data.sampleAudio,
+      data.deliveryMethod,
+      data.ebookFile,
+      data.audioFile,
+    ]
   );
   const [rows] = await pool.query('SELECT * FROM books WHERE id=?', [result.insertId]);
   res.status(201).json(rows[0]);
@@ -52,6 +72,9 @@ app.put('/api/books/:id', async (req, res) => {
     cover_image: data.coverImage,
     type: data.type,
     sample_audio: data.sampleAudio,
+    delivery_method: data.deliveryMethod,
+    ebook_file: data.ebookFile,
+    audio_file: data.audioFile,
   };
   await pool.query('UPDATE books SET ? WHERE id=?', [mapped, id]);
   const [rows] = await pool.query('SELECT * FROM books WHERE id=?', [id]);

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1415,6 +1415,9 @@ const BookForm = ({ book, onSubmit, onCancel, authors, categories }) => {
     imgPlaceholder: '',
     type: '',
     sampleAudio: '',
+    deliveryMethod: '',
+    ebookFile: '',
+    audioFile: '',
     tags: '',
     coverImage: '',
     ...(book ? (({ rating, reviews, ...rest }) => rest)(book) : {}),
@@ -1501,10 +1504,56 @@ const BookForm = ({ book, onSubmit, onCancel, authors, categories }) => {
               <option value="audio">كتاب صوتي</option>
             </select>
           </div>
-          <div>
-            <Label htmlFor="sampleAudio">رابط عينة صوتية</Label>
-            <Input id="sampleAudio" name="sampleAudio" value={formData.sampleAudio} onChange={handleChange} />
-          </div>
+          {formData.type === 'physical' && (
+            <div>
+              <Label htmlFor="deliveryMethod">طريقة التوصيل</Label>
+              <Input id="deliveryMethod" name="deliveryMethod" value={formData.deliveryMethod} onChange={handleChange} />
+            </div>
+          )}
+          {formData.type === 'ebook' && (
+            <div>
+              <Label htmlFor="ebookFile">الملف الإلكتروني</Label>
+              <input
+                id="ebookFile"
+                name="ebookFile"
+                type="file"
+                onChange={(e) => {
+                  const file = e.target.files[0];
+                  if (file) {
+                    const reader = new FileReader();
+                    reader.onloadend = () => setFormData(prev => ({ ...prev, ebookFile: reader.result }));
+                    reader.readAsDataURL(file);
+                  }
+                }}
+                className="w-full p-2 border border-gray-300 rounded-md"
+              />
+            </div>
+          )}
+          {formData.type === 'audio' && (
+            <>
+              <div>
+                <Label htmlFor="audioFile">الملف الصوتي</Label>
+                <input
+                  id="audioFile"
+                  name="audioFile"
+                  type="file"
+                  onChange={(e) => {
+                    const file = e.target.files[0];
+                    if (file) {
+                      const reader = new FileReader();
+                      reader.onloadend = () => setFormData(prev => ({ ...prev, audioFile: reader.result }));
+                      reader.readAsDataURL(file);
+                    }
+                  }}
+                  className="w-full p-2 border border-gray-300 rounded-md"
+                />
+              </div>
+              <div>
+                <Label htmlFor="sampleAudio">رابط عينة صوتية</Label>
+                <Input id="sampleAudio" name="sampleAudio" value={formData.sampleAudio} onChange={handleChange} />
+              </div>
+            </>
+          )}
           <div>
             <Label htmlFor="tags">الوسوم</Label>
             <Input id="tags" name="tags" value={formData.tags} onChange={handleChange} placeholder="مثال: دراما, مغامرة" />

--- a/src/data/siteData.js
+++ b/src/data/siteData.js
@@ -69,6 +69,7 @@ export const books = [
     format: 'غلاف ورقي',
     coverImage: '',
     type: 'physical',
+    deliveryMethod: 'شحن عادي',
     sampleAudio: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',
     tags: ''
   },
@@ -92,6 +93,7 @@ export const books = [
     format: 'غلاف مقوى',
     coverImage: '',
     type: 'physical',
+    deliveryMethod: 'توصيل سريع',
     tags: ''
   },
   {
@@ -113,6 +115,7 @@ export const books = [
     format: 'كتاب إلكتروني',
     coverImage: '',
     type: 'ebook',
+    ebookFile: '',
     tags: ''
   },
    {


### PR DESCRIPTION
## Summary
- extend books schema with delivery method and file columns
- support new fields in backend API
- show delivery or file inputs in the dashboard book form based on selected type
- add sample data for delivery methods and ebook file

## Testing
- `node --check backend/server.js`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665afc7cfc832aa1d61dbd4c57e500