### PR TITLE
Add membership and package plan types

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -110,7 +110,9 @@ CREATE TABLE IF NOT EXISTS subscription_plans (
   name VARCHAR(255) NOT NULL,
   price DECIMAL(10,2) NOT NULL,
   duration INT NOT NULL,
-  description TEXT
+  description TEXT,
+  plan_type ENUM('membership','package') NOT NULL DEFAULT 'membership',
+  package_type ENUM('ebook','audio')
 );
 
 CREATE TABLE IF NOT EXISTS subscriptions (

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -609,13 +609,25 @@ const DashboardCustomers = ({ customers, setCustomers }) => {
 }; 
 
 const PlanForm = ({ plan, onSubmit, onCancel }) => {
-  const [formData, setFormData] = useState({ name: '', price: '', duration: '', description: '', ...plan });
+  const [formData, setFormData] = useState({
+    name: '',
+    price: '',
+    duration: '',
+    description: '',
+    plan_type: 'membership',
+    package_type: 'ebook',
+    ...plan,
+  });
 
   const handleChange = (e) => setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    onSubmit({ ...formData, price: parseFloat(formData.price), duration: parseInt(formData.duration, 10) });
+    onSubmit({
+      ...formData,
+      price: parseFloat(formData.price),
+      duration: parseInt(formData.duration, 10),
+    });
   };
 
   return (
@@ -638,6 +650,22 @@ const PlanForm = ({ plan, onSubmit, onCancel }) => {
           <Label htmlFor="pdesc">الوصف</Label>
           <Textarea id="pdesc" name="description" value={formData.description} onChange={handleChange} rows={3} />
         </div>
+        <div>
+          <Label htmlFor="plan_type">نوع الخطة</Label>
+          <select id="plan_type" name="plan_type" value={formData.plan_type} onChange={handleChange} className="w-full p-2 mt-1 border border-gray-300 rounded-md">
+            <option value="membership">عضوية</option>
+            <option value="package">باقة</option>
+          </select>
+        </div>
+        {formData.plan_type === 'package' && (
+          <div>
+            <Label htmlFor="package_type">نوع الباقة</Label>
+            <select id="package_type" name="package_type" value={formData.package_type || ''} onChange={handleChange} className="w-full p-2 mt-1 border border-gray-300 rounded-md">
+              <option value="ebook">كتب إلكترونية</option>
+              <option value="audio">كتب صوتية</option>
+            </select>
+          </div>
+        )}
         <div className="flex justify-end space-x-3 rtl:space-x-reverse">
           <Button type="button" variant="outline" onClick={onCancel}>إلغاء</Button>
           <Button type="submit" className="bg-gradient-to-r from-blue-600 to-purple-600 text-white">
@@ -830,6 +858,8 @@ const DashboardPlans = ({ plans, setPlans }) => {
               <th className="px-5 py-3.5 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">الاسم</th>
               <th className="px-5 py-3.5 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">السعر</th>
               <th className="px-5 py-3.5 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">المدة</th>
+              <th className="px-5 py-3.5 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">النوع</th>
+              <th className="px-5 py-3.5 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">نوع الباقة</th>
               <th className="px-5 py-3.5 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">الإجراءات</th>
             </tr>
           </thead>
@@ -840,6 +870,8 @@ const DashboardPlans = ({ plans, setPlans }) => {
                 <td className="px-5 py-3 whitespace-nowrap text-sm text-gray-700">{p.name}</td>
                 <td className="px-5 py-3 whitespace-nowrap text-sm text-gray-700">{p.price}</td>
                 <td className="px-5 py-3 whitespace-nowrap text-sm text-gray-700">{p.duration}</td>
+                <td className="px-5 py-3 whitespace-nowrap text-sm text-gray-700">{p.plan_type}</td>
+                <td className="px-5 py-3 whitespace-nowrap text-sm text-gray-700">{p.package_type || '-'}</td>
                 <td className="px-5 py-3 whitespace-nowrap text-sm">
                   <div className="flex space-x-2 rtl:space-x-reverse justify-center">
                     <Button size="icon" variant="ghost" className="text-slate-500 hover:bg-blue-100 hover:text-blue-700 w-8 h-8" onClick={() => { setEditingPlan(p); setShowForm(true); }}><Edit className="w-4 h-4" /></Button>

--- a/src/components/SubscriptionDialog.jsx
+++ b/src/components/SubscriptionDialog.jsx
@@ -13,7 +13,7 @@ const SubscriptionDialog = ({ open, onOpenChange, book, onAddToCart }) => {
   useEffect(() => {
     (async () => {
       try {
-        setPlans(await api.getPlans());
+        setPlans(await api.getPlans({ type: 'membership' }));
       } catch (e) {
         console.error(e);
       }

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -64,7 +64,10 @@ export const api = {
   getSettings: () => request('/api/settings'),
   updateSettings: (data) => request('/api/settings', { method: 'PUT', body: JSON.stringify(data) }),
   importGoogleMerchant: () => request('/api/google-merchant/import', { method: 'POST' }),
-  getPlans: () => request('/api/plans'),
+  getPlans: (params) => {
+    const query = params ? '?' + new URLSearchParams(params).toString() : '';
+    return request(`/api/plans${query}`);
+  },
   addPlan: (data) => request('/api/plans', { method: 'POST', body: JSON.stringify(data) }),
   updatePlan: (id, data) => request(`/api/plans/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   deletePlan: (id) => request(`/api/plans/${id}`, { method: 'DELETE' }),

--- a/src/pages/AudiobookPage.jsx
+++ b/src/pages/AudiobookPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Check, Award, Star, Play, Clock, Headphones } from 'lucide-react';
 import { Button } from '@/components/ui/button.jsx';
+import api from '@/lib/api.js';
 
 const AudiobookPage = () => {
   // Mock data
@@ -22,44 +23,17 @@ const AudiobookPage = () => {
 
   const infiniteBooks = Array(15).fill(sampleBooks.slice(0, 10)).flat();
 
-  const plans = [
-    {
-      id: 'basic',
-      name: 'الأساسية',
-      price: '$9.99',
-      duration: 'شهرياً',
-      features: [
-        'كتب إلكترونية غير محدودة',
-        'استماع محدود للكتب الصوتية (مثلاً: 1 ساعة شهرياً)',
-        'وصول إلى مجموعات مختارة'
-      ]
-    },
-    {
-      id: 'pro',
-      name: 'المحترفة',
-      price: '$14.99',
-      duration: 'شهرياً',
-      popular: true,
-      features: [
-        'جميع المميزات المميزة',
-        'كتب إلكترونية وصوتية غير محدودة',
-        'تنزيل الكتب دون اتصال',
-        'وصول إلى جميع المجموعات'
-      ]
-    },
-    {
-      id: 'family',
-      name: 'العائلية',
-      price: '$49.99',
-      duration: 'شهرياً',
-      features: [
-        'مشاركة مع ٥ أفراد',
-        'الرقابة الأبوية',
-        'ملفات تعريف شخصية',
-        'جميع مميزات الباقة المحترفة'
-      ]
-    }
-  ];
+  const [plans, setPlans] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setPlans(await api.getPlans({ type: 'package', packageType: 'audio' }));
+      } catch (e) {
+        console.error(e);
+      }
+    })();
+  }, []);
 
   return (
     <main className="container mx-auto px-4 py-6 sm:py-8">
@@ -142,48 +116,22 @@ const AudiobookPage = () => {
           {plans.map((plan, index) => (
             <motion.div
               key={plan.id}
-              className={`relative bg-white rounded-2xl shadow-lg border-2 overflow-hidden ${
-                plan.popular ? 'border-blue-500 scale-105' : 'border-gray-200'
-              }`}
+              className="bg-white rounded-2xl shadow-lg border border-gray-200 p-6"
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, amount: 0.2 }}
               transition={{ duration: 0.4, delay: index * 0.1 }}
             >
-              {plan.popular && (
-                <div className="absolute top-0 left-0 right-0 bg-blue-500 text-white text-center py-2 text-sm font-medium">
-                  الأكثر شيوعاً
+              <div className="text-center mb-6">
+                <h3 className="text-xl font-bold text-gray-900 mb-1">{plan.name}</h3>
+                <div className="mb-4">
+                  <span className="text-3xl font-bold text-gray-900">{plan.price}</span>
+                  <span className="text-gray-600 text-sm mr-1">{plan.duration} يوم</span>
                 </div>
-              )}
-
-              <div className={`p-6 ${plan.popular ? 'pt-12' : 'pt-6'}`}>
-                <div className="text-center mb-6">
-                  <h3 className="text-xl font-bold text-gray-900 mb-1">{plan.name}</h3>
-                  <div className="mb-4">
-                    <span className="text-3xl font-bold text-gray-900">{plan.price}</span>
-                    <span className="text-gray-600 text-sm mr-1">{plan.duration}</span>
-                  </div>
-                </div>
-
-                <ul className="space-y-3 mb-6">
-                  {plan.features.map((feature, i) => (
-                    <li key={i} className="flex items-start text-right">
-                      <Check className="w-4 h-4 text-blue-500 mt-0.5 ml-2 rtl:mr-2 rtl:ml-0 flex-shrink-0" />
-                      <span className="text-sm text-gray-700 leading-5">{feature}</span>
-                    </li>
-                  ))}
-                </ul>
-
-                <Button
-                  className={`w-full py-3 rounded-xl font-medium transition-all duration-200 ${
-                    plan.popular
-                      ? 'bg-blue-500 hover:bg-blue-600 text-white shadow-lg'
-                      : 'bg-[#E4E6FF] hover:bg-[#d6d8f2] text-[#315dfb] border border-[#E4E6FF]'
-                  }`}
-                >
-                  اختر باقتك
-                </Button>
               </div>
+              <Button className="w-full bg-[#E4E6FF] hover:bg-[#d6d8f2] text-[#315dfb] border border-[#E4E6FF]">
+                اختر باقتك
+              </Button>
             </motion.div>
           ))}
         </div>

--- a/src/pages/EbookPage.jsx
+++ b/src/pages/EbookPage.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button.jsx';
 import { toast } from '@/components/ui/use-toast.js';
+import api from '@/lib/api.js';
 import { BookCard } from '@/components/FlashSaleSection.jsx';
 import { Check, Award, Star } from 'lucide-react';
 
@@ -19,37 +20,22 @@ const EbookPage = ({ books, authors, handleAddToCart, handleToggleWishlist, wish
     setLocalWishlist(stored);
   };
 
-  const ebooks = books.filter(book => book.format === 'كتاب إلكتروني' || book.type === 'ebook' || book.category === 'ebooks');
+  const ebooks = books.filter(
+    (book) =>
+      book.format === 'كتاب إلكتروني' || book.type === 'ebook' || book.category === 'ebooks'
+  );
 
-  const plans = [
-    {
-      name: 'الأساسية',
-      price: '$9.99',
-      period: 'شهرياً',
-      subtitle: 'الميزات الأساسية',
-      features: ['كتب إلكترونية غير محدودة', 'استماع محدود للكتب الصوتية (مدة: 1 ساعات شهرياً)', 'الوصول إلى مجموعات مختارة'],
-      message: 'تم اختيار الباقة الأساسية!',
-      isPopular: false
-    },
-    {
-      name: 'المحترفة',
-      price: '$14.99',
-      period: 'شهرياً',
-      subtitle: 'جميع الميزات المميزة',
-      features: ['كتب إلكترونية غير محدودة', 'كتب صوتية غير محدودة', 'الوصول إلى مجموعات مختارة', 'وصول مبكر حصري للإصدارات الجديدة', 'تنزيل الكتب الإلكترونية والكتب الصوتية دون اتصال'],
-      message: 'تم اختيار الباقة المحترفة!',
-      isPopular: true
-    },
-    {
-      name: 'العائلية',
-      price: '$49.99',
-      period: 'شهرياً',
-      subtitle: 'ميزات عائلية',
-      features: ['مشاركة مع ما يصل إلى 5 أفراد', 'الإرشاة الأبوية', 'ملفات تعريف شخصية', 'فئات وميزات حصرية'],
-      message: 'تم اختيار الباقة العائلية!',
-      isPopular: false
-    }
-  ];
+  const [plans, setPlans] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setPlans(await api.getPlans({ type: 'package', packageType: 'ebook' }));
+      } catch (e) {
+        console.error(e);
+      }
+    })();
+  }, []);
 
   return (
     <main className="container mx-auto px-4 py-6 sm:py-8">
@@ -93,51 +79,24 @@ const EbookPage = ({ books, authors, handleAddToCart, handleToggleWishlist, wish
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {plans.map((plan, index) => (
             <motion.div
-              key={plan.name}
-              className={`relative bg-white rounded-2xl shadow-lg border-2 overflow-hidden ${
-                plan.isPopular ? 'border-blue-500 scale-105' : 'border-gray-200'
-              }`}
+              key={plan.id}
+              className="bg-white rounded-2xl shadow-lg border border-gray-200 p-6"
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, amount: 0.2 }}
               transition={{ duration: 0.4, delay: index * 0.1 }}
             >
-              {plan.isPopular && (
-                <div className="absolute top-0 left-0 right-0 bg-blue-500 text-white text-center py-2 text-sm font-medium">
-                  الأكثر شيوعاً
+              <div className="text-center mb-6">
+                <h3 className="text-xl font-bold text-gray-900 mb-1">{plan.name}</h3>
+                <div className="mb-4">
+                  <span className="text-3xl font-bold text-gray-900">{plan.price}</span>
+                  <span className="text-gray-600 text-sm mr-1">{plan.duration} يوم</span>
                 </div>
-              )}
-              
-              <div className={`p-6 ${plan.isPopular ? 'pt-12' : 'pt-6'}`}>
-                <div className="text-center mb-6">
-                  <h3 className="text-xl font-bold text-gray-900 mb-1">{plan.name}</h3>
-                  <p className="text-gray-600 text-sm mb-4">{plan.subtitle}</p>
-                  <div className="mb-4">
-                    <span className="text-3xl font-bold text-gray-900">{plan.price}</span>
-                    <span className="text-gray-600 text-sm mr-1">{plan.period}</span>
-                  </div>
-                </div>
-
-                <ul className="space-y-3 mb-6">
-                  {plan.features.map((feature, i) => (
-                    <li key={i} className="flex items-start text-right">
-                      <Check className="w-4 h-4 text-blue-500 mt-0.5 ml-2 rtl:mr-2 rtl:ml-0 flex-shrink-0" />
-                      <span className="text-sm text-gray-700 leading-5">{feature}</span>
-                    </li>
-                  ))}
-                </ul>
-
-                <Button
-                  className={`w-full py-3 rounded-xl font-medium transition-all duration-200 
-                  ${plan.isPopular
-                      ? 'bg-blue-500 hover:bg-blue-600 text-white shadow-lg'
-                      : 'bg-[#E4E6FF] hover:bg-[#d6d8f2] text-[#315dfb] border border-[#E4E6FF]' // تم التعديل هنا: ألوان مخصصة
-                  }`}
-                  onClick={() => toast({ title: plan.message })}
-                >
-                  اختر باقتك
-                </Button>
               </div>
+              <p className="text-sm text-gray-700 mb-6 text-center">{plan.description}</p>
+              <Button className="w-full bg-[#E4E6FF] hover:bg-[#d6d8f2] text-[#315dfb] border border-[#E4E6FF]" onClick={() => toast({ title: `تم اختيار ${plan.name}` })}>
+                اختر باقتك
+              </Button>
             </motion.div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- support membership and package plans in DB
- filter plans by type in backend API
- expose plan filters in API client
- update admin dashboard to manage plan/package types
- display package plans on ebook and audiobook pages
- fetch membership plan in SubscriptionDialog

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866601dfb18832a8eb9eb90e160fc41