### PR TITLE
Hide site name next to logo

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -256,7 +256,8 @@ const Header = ({ handleFeatureClick, cartItemCount, isCustomerLoggedIn, books =
                   className="h-10 w-auto mr-2 rtl:ml-2 rtl:mr-0"
                   src="https://darmolhimon.com/wp-content/uploads/2021/07/Dar.png"
                 />
-                <span className="font-semibold text-lg">{siteSettings.siteName || 'ملهمون'}</span>
+                {/* Keep site name for screen readers but hide visually */}
+                <span className="sr-only">{siteSettings.siteName || 'ملهمون'}</span>
               </Link>
             </motion.div>
           </div>


### PR DESCRIPTION
## Summary
- keep site name only for screen readers in `Header`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866641cd7ec832a9df4081d0632b105