### PR TITLE
Add ebook reader page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ import AudiobookPage from '@/pages/AudiobookPage.jsx';
 import EbookPage from '@/pages/EbookPage.jsx';
 import ReadSamplePage from '@/pages/ReadSamplePage.jsx';
 import ListenSamplePage from '@/pages/ListenSamplePage.jsx';
+import EbookReaderPage from '@/pages/EbookReaderPage.jsx';
 import SearchResultsPage from '@/pages/SearchResultsPage.jsx';
 import AddToCartDialog from '@/components/AddToCartDialog.jsx';
 
@@ -351,6 +352,7 @@ const App = () => {
               <Route path="/ebooks" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><EbookPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} wishlist={wishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
               <Route path="/audiobooks" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><AudiobookPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} wishlist={wishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
               <Route path="/read/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><ReadSamplePage books={books} /></PageLayout></MainLayout>} />
+              <Route path="/reader/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><EbookReaderPage books={books} /></PageLayout></MainLayout>} />
               <Route path="/listen/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><ListenSamplePage books={books} /></PageLayout></MainLayout>} />
               <Route path="*" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><NotFoundPage /></PageLayout></MainLayout>} />
             </Routes>

--- a/src/pages/EbookReaderPage.jsx
+++ b/src/pages/EbookReaderPage.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button.jsx';
+import { Slider } from '@/components/ui/slider.jsx';
+
+const EbookReaderPage = ({ books }) => {
+  const { id } = useParams();
+  const book = books.find(b => b.id.toString() === id);
+
+  const [fontSize, setFontSize] = useState(18);
+  const [darkMode, setDarkMode] = useState(false);
+  const [dir, setDir] = useState('rtl');
+
+  if (!book) {
+    return <div className="container mx-auto px-4 py-8 text-center">جاري التحميل...</div>;
+  }
+
+  const content = book.description || 'لا يوجد محتوى متاح.';
+
+  return (
+    <div className={`min-h-screen ${darkMode ? 'bg-gray-900 text-gray-100' : 'bg-white text-gray-800'}`} dir={dir}>
+      <div className="container mx-auto px-4 py-6">
+        <div className="mb-4 flex justify-between items-center">
+          <Link to={`/book/${id}`} className="text-blue-600 hover:underline">عودة لتفاصيل الكتاب</Link>
+          <div className="flex items-center space-x-3 rtl:space-x-reverse">
+            <Button size="sm" variant="outline" onClick={() => setDarkMode(!darkMode)}>
+              {darkMode ? 'وضع النهار' : 'وضع الليل'}
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => setDir(dir === 'rtl' ? 'ltr' : 'rtl')}>
+              {dir === 'rtl' ? 'LTR' : 'RTL'}
+            </Button>
+          </div>
+        </div>
+        <div className="mb-6 flex items-center space-x-4 rtl:space-x-reverse">
+          <span className="whitespace-nowrap">حجم الخط</span>
+          <Slider
+            className="max-w-xs"
+            min={14}
+            max={24}
+            step={1}
+            value={[fontSize]}
+            onValueChange={([v]) => setFontSize(v)}
+          />
+          <span>{fontSize}px</span>
+        </div>
+        <h1 className="text-2xl font-bold mb-4">{book.title}</h1>
+        <div style={{ fontSize: `${fontSize}px` }} className="leading-loose whitespace-pre-line">
+          {content}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EbookReaderPage;


### PR DESCRIPTION
## Summary
- add `EbookReaderPage` for purchased books
- wire `/reader/:id` route to new reader page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866666e5280832a8772e9f7d0392c1a