### PR TITLE
Fix JSX bracket in Dashboard sidebar

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -90,7 +90,7 @@ const DashboardSidebar = ({ dashboardSection, setDashboardSection }) => {
               {item.name}
             </button>
           );
-        })
+        })}
       </nav>
       <Button
         asChild


### PR DESCRIPTION
## Summary
- close the nav items map expression properly in the sidebar

## Testing
- `eslint src/components/Dashboard.jsx` *(fails: couldn't find eslint config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686805f2fa8c832a9e91d362f0ebb19a