### PR TITLE
Fix DashboardSidebar props

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -45,7 +45,7 @@ import { toast } from '@/components/ui/use-toast.js';
 
 import { Link } from 'react-router-dom';
 
-const DashboardSidebar = ({ dashboardSection, setDashboardSection }) => {
+const DashboardSidebar = ({ dashboardSection, setDashboardSection, sidebarOpen, setSidebarOpen }) => {
   const navItems = [
     { id: 'overview', name: 'نظرة عامة', icon: BarChart3 },
     { id: 'books', name: 'إدارة الكتب', icon: BookOpen },


### PR DESCRIPTION
## Summary
- pass sidebarOpen props into `DashboardSidebar` so the JSX parses correctly

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686806f8ef40832aa9705bfe153ee08e