### PR TITLE
Add payment method templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Authentication uses Firebase Auth. New accounts are created with `createUserWith
 Set `GOOGLE_MERCHANT_ID` and `GOOGLE_API_KEY` in your `.env` file to enable importing products from Google Merchant Center. In the dashboard settings you can trigger "استيراد من Google Merchant" to fetch and add products as books.
 
 ## Payment Methods
-Payment methods are stored in the `payment_methods` collection in Firestore. Each method can hold a JSON configuration containing your gateway keys (for example Stripe publishable/secret keys or PayPal client details). The dashboard lets you edit this JSON for every method. Only Firebase is required – no additional backend is needed for payments.
+Payment methods are stored in the `payment_methods` collection in Firestore. Each method can hold a JSON configuration containing your gateway keys (for example Stripe publishable/secret keys or PayPal client details). The dashboard lets you edit this JSON for every method. When creating a new method you can now choose from a list of popular gateways (Stripe, PayPal, STC Pay and others) and their basic configuration template will be filled in automatically. Only Firebase is required – no additional backend is needed for payments.
 
 ## Notes
 - Data in the dashboard is persisted in Firebase. The optional PHP backend is only used for the Google Merchant import.

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -5,6 +5,7 @@ import FormattedPrice from './FormattedPrice.jsx';
 import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button.jsx';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu.jsx';
+import { paymentMethods as paymentMethodTemplates } from '@/data/siteData.js';
 import {
   BookOpen,
   Users,
@@ -1536,9 +1537,21 @@ const PaymentMethodForm = ({ method, onSubmit, onCancel }) => {
     test_mode: method?.test_mode || false,
     config: method?.config ? JSON.stringify(method.config, null, 2) : ''
   });
+  const [selectedTemplate, setSelectedTemplate] = useState('');
   const handleChange = (e) => {
     const { name, type, checked, value } = e.target;
     setFormData(prev => ({ ...prev, [name]: type === 'checkbox' ? checked : value }));
+  };
+  const handleTemplateChange = (e) => {
+    const tpl = paymentMethodTemplates.find(t => t.id.toString() === e.target.value);
+    setSelectedTemplate(e.target.value);
+    if (tpl) {
+      setFormData({
+        name: tpl.name,
+        test_mode: tpl.test_mode,
+        config: JSON.stringify(tpl.config, null, 2)
+      });
+    }
   };
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -1549,6 +1562,20 @@ const PaymentMethodForm = ({ method, onSubmit, onCancel }) => {
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="dashboard-card p-6 rounded-xl shadow-lg bg-white">
       <h3 className="text-xl font-semibold mb-5 text-gray-700">{method ? 'تعديل طريقة' : 'إضافة طريقة جديدة'}</h3>
       <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <Label htmlFor="templateSelect">اختر من النماذج</Label>
+          <select
+            id="templateSelect"
+            value={selectedTemplate}
+            onChange={handleTemplateChange}
+            className="w-full p-2 mt-1 border border-gray-300 rounded-md"
+          >
+            <option value="">-- اختر طريقة دفع --</option>
+            {paymentMethodTemplates.map(t => (
+              <option key={t.id} value={t.id}>{t.name}</option>
+            ))}
+          </select>
+        </div>
         <div>
           <Label htmlFor="mname">الاسم</Label>
           <Input id="mname" name="name" value={formData.name} onChange={handleChange} required />


### PR DESCRIPTION
## Summary
- update payment-method docs
- allow choosing common payment gateway templates when adding a method

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e533fdc4832ab51f92d8d8e5bc3d