### PR TITLE
Add Excel import dialog for books

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "firebase": "^9.23.0",
+        "xlsx": "^0.18.5",
         "framer-motion": "^10.16.4",
         "lucide-react": "^0.292.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-router-dom": "^6.16.0",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7",
-    "firebase": "^9.23.0"
+    "firebase": "^9.23.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@babel/generator": "^7.27.0",

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -43,6 +43,7 @@ import {
   DialogClose,
 } from '@/components/ui/dialog.jsx';
 import { toast } from '@/components/ui/use-toast.js';
+import ExcelImportDialog from './ExcelImportDialog.jsx';
 
 import { Link } from 'react-router-dom';
 
@@ -251,6 +252,7 @@ const DashboardAuthors = ({ authors, setAuthors }) => {
           </tbody>
         </table>
       </div>
+      <ExcelImportDialog open={importOpen} onOpenChange={setImportOpen} onImport={handleImportBooks} />
     </motion.div>
   );
 };
@@ -1965,6 +1967,7 @@ const BookForm = ({ book, onSubmit, onCancel, authors, categories }) => {
 const DashboardBooks = ({ books, setBooks, authors, categories, handleFeatureClick }) => {
   const [showForm, setShowForm] = useState(false);
   const [editingBook, setEditingBook] = useState(null);
+  const [importOpen, setImportOpen] = useState(false);
 
   const handleAddBook = async (data) => {
     try {
@@ -2000,6 +2003,19 @@ const DashboardBooks = ({ books, setBooks, authors, categories, handleFeatureCli
     }
   };
 
+  const handleImportBooks = async (list) => {
+    for (const item of list) {
+      try {
+        const data = { ...item, prices: { AED: item.price || 0 } };
+        const newBook = await api.addBook(data);
+        setBooks(prev => [newBook, ...prev]);
+      } catch (err) {
+        console.error('Import error', err);
+      }
+    }
+    toast({ title: 'تم الاستيراد بنجاح!' });
+  };
+
   if (showForm) {
     return <BookForm book={editingBook} onSubmit={editingBook ? handleEditBook : handleAddBook} onCancel={() => { setShowForm(false); setEditingBook(null); }} authors={authors} categories={categories} />;
   }
@@ -2013,13 +2029,18 @@ const DashboardBooks = ({ books, setBooks, authors, categories, handleFeatureCli
     >
       <div className="flex flex-col sm:flex-row justify-between items-center">
         <h2 className="text-2xl font-semibold text-gray-700 mb-3 sm:mb-0">قائمة الكتب</h2>
-        <Button 
-          className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white shadow-md"
-          onClick={() => { setEditingBook(null); setShowForm(true); }}
-        >
-          <Plus className="w-5 h-5 mr-2 rtl:ml-2 rtl:mr-0" />
-          إضافة كتاب جديد
-        </Button>
+        <div className="flex gap-2">
+          <Button
+            className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white shadow-md"
+            onClick={() => { setEditingBook(null); setShowForm(true); }}
+          >
+            <Plus className="w-5 h-5 mr-2 rtl:ml-2 rtl:mr-0" />
+            إضافة كتاب جديد
+          </Button>
+          <Button variant="outline" onClick={() => setImportOpen(true)}>
+            استيراد من Excel
+          </Button>
+        </div>
       </div>
 
       <div className="dashboard-card rounded-xl shadow-lg overflow-hidden bg-white">

--- a/src/components/ExcelImportDialog.jsx
+++ b/src/components/ExcelImportDialog.jsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import * as XLSX from 'xlsx';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose } from './ui/dialog.jsx';
+import { Button } from './ui/button.jsx';
+import { Input } from './ui/input.jsx';
+import { Label } from './ui/label.jsx';
+
+const FIELDS = [
+  { key: 'title', label: 'العنوان' },
+  { key: 'author', label: 'المؤلف' },
+  { key: 'price', label: 'السعر' },
+  { key: 'category', label: 'الفئة' },
+  { key: 'description', label: 'الوصف' },
+];
+
+export default function ExcelImportDialog({ open, onOpenChange, onImport }) {
+  const [headers, setHeaders] = useState([]);
+  const [rows, setRows] = useState([]);
+  const [mapping, setMapping] = useState({});
+
+  const handleFile = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (evt) => {
+      const data = new Uint8Array(evt.target.result);
+      const workbook = XLSX.read(data, { type: 'array' });
+      const ws = workbook.Sheets[workbook.SheetNames[0]];
+      const json = XLSX.utils.sheet_to_json(ws, { defval: '' });
+      setHeaders(Object.keys(json[0] || {}));
+      setRows(json);
+    };
+    reader.readAsArrayBuffer(file);
+  };
+
+  const handleImport = async () => {
+    if (!rows.length) return;
+    const books = rows.map(r => {
+      const b = {};
+      FIELDS.forEach(f => {
+        const col = mapping[f.key];
+        if (col) b[f.key] = r[col];
+      });
+      if (b.price) b.price = parseFloat(b.price) || 0;
+      return b;
+    });
+    await onImport(books);
+    setHeaders([]);
+    setRows([]);
+    setMapping({});
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="space-y-4">
+        <DialogHeader>
+          <DialogTitle>استيراد كتب من Excel</DialogTitle>
+        </DialogHeader>
+        {!rows.length ? (
+          <div>
+            <Label htmlFor="xls-file">اختر ملف Excel</Label>
+            <Input id="xls-file" type="file" accept=".xls,.xlsx" onChange={handleFile} />
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {FIELDS.map(f => (
+              <div key={f.key} className="flex items-center space-x-2 rtl:space-x-reverse">
+                <Label className="w-28" htmlFor={`map-${f.key}`}>{f.label}</Label>
+                <select
+                  id={`map-${f.key}`}
+                  className="flex-grow p-2 border border-gray-300 rounded-md"
+                  value={mapping[f.key] || ''}
+                  onChange={(e) => setMapping(prev => ({ ...prev, [f.key]: e.target.value }))}
+                >
+                  <option value="">-- تجاهل --</option>
+                  {headers.map(h => (
+                    <option key={h} value={h}>{h}</option>
+                  ))}
+                </select>
+              </div>
+            ))}
+          </div>
+        )}
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">إلغاء</Button>
+          </DialogClose>
+          {rows.length > 0 && (
+            <Button onClick={handleImport}>استيراد</Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- enable Excel imports by adding `xlsx` dependency
- create `ExcelImportDialog` component for mapping Excel columns
- integrate import dialog into Dashboard Books section

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686976f0752c832ab99f1089157db7ae