### PR TITLE
Add CSV import support for books

### DIFF
--- a/src/components/CsvImportDialog.jsx
+++ b/src/components/CsvImportDialog.jsx
@@ -13,7 +13,7 @@ const FIELDS = [
   { key: 'description', label: 'الوصف' },
 ];
 
-export default function ExcelImportDialog({ open, onOpenChange, onImport }) {
+export default function CsvImportDialog({ open, onOpenChange, onImport }) {
   const [headers, setHeaders] = useState([]);
   const [rows, setRows] = useState([]);
   const [mapping, setMapping] = useState({});
@@ -21,16 +21,23 @@ export default function ExcelImportDialog({ open, onOpenChange, onImport }) {
   const handleFile = (e) => {
     const file = e.target.files[0];
     if (!file) return;
+    const isCsv = file.name.toLowerCase().endsWith('.csv');
     const reader = new FileReader();
     reader.onload = (evt) => {
-      const data = new Uint8Array(evt.target.result);
-      const workbook = XLSX.read(data, { type: 'array' });
+      let workbook;
+      if (isCsv) {
+        workbook = XLSX.read(evt.target.result, { type: 'string' });
+      } else {
+        const data = new Uint8Array(evt.target.result);
+        workbook = XLSX.read(data, { type: 'array' });
+      }
       const ws = workbook.Sheets[workbook.SheetNames[0]];
       const json = XLSX.utils.sheet_to_json(ws, { defval: '' });
       setHeaders(Object.keys(json[0] || {}));
       setRows(json);
     };
-    reader.readAsArrayBuffer(file);
+    if (isCsv) reader.readAsText(file);
+    else reader.readAsArrayBuffer(file);
   };
 
   const handleImport = async () => {
@@ -55,12 +62,12 @@ export default function ExcelImportDialog({ open, onOpenChange, onImport }) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="space-y-4">
         <DialogHeader>
-          <DialogTitle>استيراد كتب من Excel</DialogTitle>
+          <DialogTitle>استيراد كتب من ملف CSV</DialogTitle>
         </DialogHeader>
         {!rows.length ? (
           <div>
-            <Label htmlFor="xls-file">اختر ملف Excel</Label>
-            <Input id="xls-file" type="file" accept=".xls,.xlsx" onChange={handleFile} />
+            <Label htmlFor="xls-file">اختر ملف CSV أو Excel</Label>
+            <Input id="xls-file" type="file" accept=".csv,.xls,.xlsx" onChange={handleFile} />
           </div>
         ) : (
           <div className="space-y-3">

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -43,7 +43,7 @@ import {
   DialogClose,
 } from '@/components/ui/dialog.jsx';
 import { toast } from '@/components/ui/use-toast.js';
-import ExcelImportDialog from './ExcelImportDialog.jsx';
+import CsvImportDialog from './CsvImportDialog.jsx';
 
 import { Link } from 'react-router-dom';
 
@@ -252,7 +252,7 @@ const DashboardAuthors = ({ authors, setAuthors }) => {
           </tbody>
         </table>
       </div>
-      <ExcelImportDialog open={importOpen} onOpenChange={setImportOpen} onImport={handleImportBooks} />
+      <CsvImportDialog open={importOpen} onOpenChange={setImportOpen} onImport={handleImportBooks} />
     </motion.div>
   );
 };
@@ -2038,7 +2038,7 @@ const DashboardBooks = ({ books, setBooks, authors, categories, handleFeatureCli
             إضافة كتاب جديد
           </Button>
           <Button variant="outline" onClick={() => setImportOpen(true)}>
-            استيراد من Excel
+            استيراد من ملف CSV
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- support importing book lists from CSV
- rename `ExcelImportDialog` to `CsvImportDialog`
- update dashboard UI to reflect CSV import option

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68697c8cb648832a95a41d7c01806272