### PR TITLE
Fix Google Merchant import button

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -2139,7 +2139,10 @@ const DashboardSettings = ({ siteSettings, setSiteSettings }) => {
 
   const handleImport = async () => {
     try {
-      await api.importGoogleMerchant();
+      await api.importGoogleMerchant({
+        googleMerchantId: formData.googleMerchantId,
+        googleApiKey: formData.googleApiKey,
+      });
       toast({ title: 'تم استيراد الكتب بنجاح!' });
     } catch (err) {
       toast({ title: 'خطأ في الاستيراد', variant: 'destructive' });

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -18,7 +18,11 @@ async function request(url, options = {}) {
 // Export Firebase API by default and keep Google Merchant import via legacy backend
 export const api = {
   ...firebaseApi,
-  importGoogleMerchant: () => request('/api/google-merchant/import', { method: 'POST' }),
+  importGoogleMerchant: (cfg = {}) =>
+    request('/api/google-merchant/import', {
+      method: 'POST',
+      body: JSON.stringify(cfg),
+    }),
 };
 
 export default api;


### PR DESCRIPTION
## Summary
- handle Google Merchant credentials directly from settings form
- allow API to accept credentials in request

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698ae4011c832aba15a8204e004d62