### PR TITLE
Fix CSV import dialog for books

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -2113,6 +2113,7 @@ const DashboardBooks = ({ books, setBooks, authors, categories, handleFeatureCli
           </table>
         </div>
       </div>
+      <CsvImportDialog open={importOpen} onOpenChange={setImportOpen} onImport={handleImportBooks} />
     </motion.div>
   );
 };


### PR DESCRIPTION
## Summary
- wire up CSV import dialog in the books section so it shows when clicking the import button

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698c2c85f8832aa8e36d61225d9bc8