### PR TITLE
Add import button regardless of data

### DIFF
--- a/src/components/CsvImportDialog.jsx
+++ b/src/components/CsvImportDialog.jsx
@@ -135,9 +135,9 @@ export default function CsvImportDialog({ open, onOpenChange, onImport }) {
           <DialogClose asChild>
             <Button variant="outline">إلغاء</Button>
           </DialogClose>
-          {rows.length > 0 && (
-            <Button onClick={handleImport}>استيراد</Button>
-          )}
+          <Button onClick={handleImport} disabled={!rows.length}>
+            استيراد
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- make the CSV import button visible at all times

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698d6ff6ac832a8bca659db47791d3