### PR TITLE
Fix rating display when missing

### DIFF
--- a/src/components/BookBestsellerSection.jsx
+++ b/src/components/BookBestsellerSection.jsx
@@ -43,10 +43,10 @@ const BestsellerCard = ({ book, handleAddToCart, handleToggleWishlist, index, is
       </Link>
       <p className="text-gray-500 text-[10px] sm:text-xs mb-1 sm:mb-2 hover:text-blue-500">{book.author}</p>
 
-      <div className="flex items-center mb-1 sm:mb-2 bg-gray-100 rounded-sm px-1 w-max">
-        <Star className="w-3 h-3 sm:w-3.5 sm:h-3.5 text-blue-600 fill-blue-600" />
-        <span className="text-[10px] sm:text-xs text-gray-600 mr-1.5 rtl:ml-1.5 rtl:mr-0">{book.rating.toFixed(1)}/5 ({book.reviews})</span>
-      </div>
+        <div className="flex items-center mb-1 sm:mb-2 bg-gray-100 rounded-sm px-1 w-max">
+          <Star className="w-3 h-3 sm:w-3.5 sm:h-3.5 text-blue-600 fill-blue-600" />
+          <span className="text-[10px] sm:text-xs text-gray-600 mr-1.5 rtl:ml-1.5 rtl:mr-0">{Number(book.rating ?? 0).toFixed(1)}/5 ({book.reviews ?? 0})</span>
+        </div>
 
       <div className="flex items-baseline mb-1 sm:mb-2">
         {book.originalPrice && (

--- a/src/components/FlashSaleSection.jsx
+++ b/src/components/FlashSaleSection.jsx
@@ -98,7 +98,7 @@ const BookCard = ({ book, handleAddToCart, handleToggleWishlist, index, isInWish
       
         <div className="flex items-center mb-1 sm:mb-1.5 bg-blue-600/10 rounded-sm px-1 w-max">
           <Star className="w-2.5 h-2.5 sm:w-3 sm:h-3 text-blue-600 fill-blue-600" />
-          <span className="text-[9px] sm:text-[10px] text-gray-600 mr-2 rtl:ml-2 rtl:mr-0">{book.rating.toFixed(1)}/5 ({book.reviews})</span>
+          <span className="text-[9px] sm:text-[10px] text-gray-600 mr-2 rtl:ml-2 rtl:mr-0">{Number(book.rating ?? 0).toFixed(1)}/5 ({book.reviews ?? 0})</span>
         </div>
 
         <div className="flex items-baseline justify-between mb-1 sm:mb-1.5 w-full">

--- a/src/components/YouMayAlsoLikeSection.jsx
+++ b/src/components/YouMayAlsoLikeSection.jsx
@@ -62,7 +62,7 @@ const YouMayAlsoLikeSection = ({ books, handleAddToCart, handleToggleWishlist, w
                 
                 <div className="flex items-center mb-1 sm:mb-2 bg-gray-100 rounded-sm px-1 w-max">
                   <Star className="w-3 h-3 sm:w-3.5 sm:h-3.5 text-blue-600 fill-blue-600" />
-                  <span className="text-[10px] sm:text-xs text-gray-600 mr-1.5 rtl:ml-1.5 rtl:mr-0">{book.rating.toFixed(1)}/5 ({book.reviews})</span>
+                  <span className="text-[10px] sm:text-xs text-gray-600 mr-1.5 rtl:ml-1.5 rtl:mr-0">{Number(book.rating ?? 0).toFixed(1)}/5 ({book.reviews ?? 0})</span>
                 </div>
                 
                 <div className="flex items-baseline mb-1 sm:mb-2">


### PR DESCRIPTION
## Summary
- handle undefined rating in book cards by defaulting to 0

## Testing
- `grep -n "toFixed" src/components/FlashSaleSection.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68698fd52c90832a9e422729b6ed4d82