### PR TITLE
Fix toast dismiss prop

### DIFF
--- a/src/components/ui/toaster.jsx
+++ b/src/components/ui/toaster.jsx
@@ -10,25 +10,33 @@ import { useToast } from '@/components/ui/use-toast';
 import React from 'react';
 
 export function Toaster() {
-	const { toasts } = useToast();
+        const { toasts } = useToast();
 
-	return (
-		<ToastProvider>
-			{toasts.map(({ id, title, description, action, ...props }) => {
-				return (
-					<Toast key={id} {...props}>
-						<div className="grid gap-1">
-							{title && <ToastTitle>{title}</ToastTitle>}
-							{description && (
-								<ToastDescription>{description}</ToastDescription>
-							)}
-						</div>
-						{action}
-						<ToastClose />
-					</Toast>
-				);
-			})}
-			<ToastViewport />
-		</ToastProvider>
-	);
+        return (
+                <ToastProvider>
+                        {toasts.map(({ id, title, description, action, ...props }) => {
+                                const { dismiss, ...toastProps } = props;
+
+                                return (
+                                        <Toast
+                                                key={id}
+                                                {...toastProps}
+                                                onOpenChange={(open) => {
+                                                        if (!open) dismiss?.();
+                                                }}
+                                        >
+                                                <div className="grid gap-1">
+                                                        {title && <ToastTitle>{title}</ToastTitle>}
+                                                        {description && (
+                                                                <ToastDescription>{description}</ToastDescription>
+                                                        )}
+                                                </div>
+                                                {action}
+                                                <ToastClose />
+                                        </Toast>
+                                );
+                        })}
+                        <ToastViewport />
+                </ToastProvider>
+        );
 }


### PR DESCRIPTION
## Summary
- avoid passing `dismiss` to DOM elements in Toaster
- attach dismiss logic to `onOpenChange`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699175ea44832a82b89041a278eb4a