### PR TITLE
Handle multi-category import and show limited categories

### DIFF
--- a/src/components/CategoriesSection.jsx
+++ b/src/components/CategoriesSection.jsx
@@ -11,6 +11,7 @@ const CategoriesSection = ({ categories }) => {
         <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-12 gap-2 sm:gap-3">
           {categories.map((category, index) => {
             const IconComponent = Icons[category.icon] || Icons.BookOpen;
+            const link = category.id === 'more' ? '/category/all' : `/category/${category.id}`;
             return (
               <motion.div
                 key={category.id}
@@ -21,7 +22,7 @@ const CategoriesSection = ({ categories }) => {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: index * 0.04 }}
               >
-                <Link to={`/category/${category.id}`} className="flex flex-col items-center w-full">
+                <Link to={link} className="flex flex-col items-center w-full">
                   <div className="bg-slate-100 p-2 sm:p-2.5 rounded-md mb-1.5 transition-colors duration-200 group-hover:bg-blue-500">
                     <IconComponent className="w-4 h-4 sm:w-5 sm:h-5 text-blue-600 transition-colors duration-200 group-hover:text-white" />
                   </div>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -2023,24 +2023,30 @@ const DashboardBooks = ({ books, setBooks, authors, categories, setCategories, h
       try {
         let categoryId = item.category;
         if (item.category) {
-          const existing = currentCategories.find(
-            c => c.id === item.category || c.name === item.category
-          );
-          if (!existing) {
-            const newCat = await api.addCategory({
-              name: item.category,
-              icon: 'BookOpen',
-            });
-            currentCategories = [newCat, ...currentCategories];
-            setCategories(prev => [newCat, ...prev]);
-            categoryId = newCat.id;
-          } else {
-            categoryId = existing.id;
+          const names = String(item.category)
+            .split(',')
+            .map((c) => c.trim())
+            .filter(Boolean);
+          for (let i = 0; i < names.length; i++) {
+            const name = names[i];
+            let existing = currentCategories.find(
+              (c) => c.id === name || c.name === name
+            );
+            if (!existing) {
+              existing = await api.addCategory({ name, icon: 'BookOpen' });
+              currentCategories = [...currentCategories, existing];
+              setCategories((prev) => [...prev, existing]);
+            }
+            if (i === 0) categoryId = existing.id;
           }
         }
-        const data = { ...item, category: categoryId, prices: { AED: item.price || 0 } };
+        const data = {
+          ...item,
+          category: categoryId,
+          prices: { AED: item.price || 0 },
+        };
         const newBook = await api.addBook(data);
-        setBooks(prev => [newBook, ...prev]);
+        setBooks((prev) => [newBook, ...prev]);
       } catch (err) {
         console.error('Import error', err);
       }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -9,29 +9,35 @@ import BookBestsellerSection from '@/components/BookBestsellerSection.jsx';
 import FeaturesSection from '@/components/FeaturesSection.jsx';
 import { TrendingUp } from 'lucide-react';
 
-const HomePage = ({ 
-  books, 
-  authors, 
-  heroSlides, 
-  categories, 
-  recentSearchBooks, 
-  bestsellerBooks, 
+const HomePage = ({
+  books,
+  authors,
+  heroSlides,
+  categories,
+  recentSearchBooks,
+  bestsellerBooks,
   featuresData: features,
   banners,
-  handleAddToCart, 
+  handleAddToCart,
   handleToggleWishlist,
   wishlist, 
-  handleFeatureClick 
+  handleFeatureClick
 }) => {
+  const displayedCategories = React.useMemo(() => {
+    const list = categories.slice(0, 11);
+    if (categories.length > 11) {
+      list.push({ id: 'more', name: 'المزيد', icon: 'Menu' });
+    }
+    return list;
+  }, [categories]);
+
   return (
     <>
       <HeroSection slides={heroSlides} />
-      <CategoriesSection 
-        categories={categories} 
-      />
-      <FlashSaleSection 
-        books={books} 
-        handleAddToCart={handleAddToCart} 
+      <CategoriesSection categories={displayedCategories} />
+      <FlashSaleSection
+        books={books}
+        handleAddToCart={handleAddToCart}
         handleToggleWishlist={handleToggleWishlist}
         wishlist={wishlist}
       />


### PR DESCRIPTION
## Summary
- parse comma-separated categories when importing books and avoid duplicates
- limit home page to 11 categories plus a "more" button
- link "more" button in categories section to `/category/all`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686999a5a8e4832aa72c1f351b446b81