### PR TITLE
Show price only when no discount

### DIFF
--- a/src/components/BookBestsellerSection.jsx
+++ b/src/components/BookBestsellerSection.jsx
@@ -48,15 +48,32 @@ const BestsellerCard = ({ book, handleAddToCart, handleToggleWishlist, index, is
           <span className="text-[10px] sm:text-xs text-gray-600 mr-1.5 rtl:ml-1.5 rtl:mr-0">{Number(book.rating ?? 0).toFixed(1)}/5 ({book.reviews ?? 0})</span>
         </div>
 
-      <div className="flex items-baseline mb-1 sm:mb-2">
-        {book.originalPrice && (
-          <span className="text-gray-400 old-price text-[10px] sm:text-xs ml-1.5 rtl:mr-1.5 rtl:ml-0">
-            <FormattedPrice value={book.originalPrice} />
-          </span>
-        )}
-        <span className="font-bold text-blue-600 text-sm sm:text-lg"><FormattedPrice book={book} /></span>
-      </div>
-      <p className="text-[10px] sm:text-xs text-blue-600 bg-blue-600/10 rounded-sm px-1 mb-2 sm:mb-3">وفر: <FormattedPrice value={book.originalPrice && book.price ? (book.originalPrice - book.price) : 0} /></p>
+      {(() => {
+        const hasDiscount = book.price && book.originalPrice && book.price !== book.originalPrice;
+        return (
+          <>
+            <div className="flex items-baseline mb-1 sm:mb-2">
+              {hasDiscount && (
+                <span className="text-gray-400 old-price text-[10px] sm:text-xs ml-1.5 rtl:mr-1.5 rtl:ml-0">
+                  <FormattedPrice value={book.originalPrice} />
+                </span>
+              )}
+              <span className="font-bold text-blue-600 text-sm sm:text-lg">
+                {book.price ? (
+                  <FormattedPrice book={book} />
+                ) : (
+                  <FormattedPrice value={book.originalPrice} />
+                )}
+              </span>
+            </div>
+            {hasDiscount && (
+              <p className="text-[10px] sm:text-xs text-blue-600 bg-blue-600/10 rounded-sm px-1 mb-2 sm:mb-3">
+                وفر: <FormattedPrice value={book.originalPrice - book.price} />
+              </p>
+            )}
+          </>
+        );
+      })()}
     </div>
 
     <Button

--- a/src/components/FlashSaleSection.jsx
+++ b/src/components/FlashSaleSection.jsx
@@ -101,17 +101,32 @@ const BookCard = ({ book, handleAddToCart, handleToggleWishlist, index, isInWish
           <span className="text-[9px] sm:text-[10px] text-gray-600 mr-2 rtl:ml-2 rtl:mr-0">{Number(book.rating ?? 0).toFixed(1)}/5 ({book.reviews ?? 0})</span>
         </div>
 
-        <div className="flex items-baseline justify-between mb-1 sm:mb-1.5 w-full">
-          <span className="font-bold text-blue-600 text-xs sm:text-sm"><FormattedPrice book={book} /></span>
-          {book.originalPrice && (
-            <span className="text-gray-400 old-price text-[9px] sm:text-[10px] rtl:ml-1 rtl:mr-0">
-              <FormattedPrice value={book.originalPrice} />
-            </span>
-          )}
-        </div>
-         <p className="text-[9px] sm:text-[10px] text-gray-600 bg-gray-600/10 rounded-sm px-1 text-center">
-           وفر: <FormattedPrice value={(book.originalPrice && book.price ? (book.originalPrice - book.price) : 0)} />
-         </p>
+        {(() => {
+          const hasDiscount = book.price && book.originalPrice && book.price !== book.originalPrice;
+          return (
+            <>
+              <div className="flex items-baseline justify-between mb-1 sm:mb-1.5 w-full">
+                <span className="font-bold text-blue-600 text-xs sm:text-sm">
+                  {book.price ? (
+                    <FormattedPrice book={book} />
+                  ) : (
+                    <FormattedPrice value={book.originalPrice} />
+                  )}
+                </span>
+                {hasDiscount && (
+                  <span className="text-gray-400 old-price text-[9px] sm:text-[10px] rtl:ml-1 rtl:mr-0">
+                    <FormattedPrice value={book.originalPrice} />
+                  </span>
+                )}
+              </div>
+              {hasDiscount && (
+                <p className="text-[9px] sm:text-[10px] text-gray-600 bg-gray-600/10 rounded-sm px-1 text-center">
+                  وفر: <FormattedPrice value={book.originalPrice - book.price} />
+                </p>
+              )}
+            </>
+          );
+        })()}
     </div>
   </motion.div>
 );

--- a/src/components/YouMayAlsoLikeSection.jsx
+++ b/src/components/YouMayAlsoLikeSection.jsx
@@ -65,15 +65,32 @@ const YouMayAlsoLikeSection = ({ books, handleAddToCart, handleToggleWishlist, w
                   <span className="text-[10px] sm:text-xs text-gray-600 mr-1.5 rtl:ml-1.5 rtl:mr-0">{Number(book.rating ?? 0).toFixed(1)}/5 ({book.reviews ?? 0})</span>
                 </div>
                 
-                <div className="flex items-baseline mb-1 sm:mb-2">
-                  {book.originalPrice && (
-                    <span className="text-gray-400 old-price text-[10px] sm:text-xs ml-1.5 rtl:mr-1.5 rtl:ml-0">
-                      <FormattedPrice value={book.originalPrice} />
-                    </span>
-                  )}
-                  <span className="font-bold text-blue-600 text-sm sm:text-lg"><FormattedPrice book={book} /></span>
-                </div>
-                 <p className="text-[10px] sm:text-xs text-blue-600 bg-blue-600/10 rounded-sm px-1 mb-2 sm:mb-3">وفر: <FormattedPrice value={book.originalPrice && book.price ? (book.originalPrice - book.price) : 0} /></p>
+                {(() => {
+                  const hasDiscount = book.price && book.originalPrice && book.price !== book.originalPrice;
+                  return (
+                    <>
+                      <div className="flex items-baseline mb-1 sm:mb-2">
+                        {hasDiscount && (
+                          <span className="text-gray-400 old-price text-[10px] sm:text-xs ml-1.5 rtl:mr-1.5 rtl:ml-0">
+                            <FormattedPrice value={book.originalPrice} />
+                          </span>
+                        )}
+                        <span className="font-bold text-blue-600 text-sm sm:text-lg">
+                          {book.price ? (
+                            <FormattedPrice book={book} />
+                          ) : (
+                            <FormattedPrice value={book.originalPrice} />
+                          )}
+                        </span>
+                      </div>
+                      {hasDiscount && (
+                        <p className="text-[10px] sm:text-xs text-blue-600 bg-blue-600/10 rounded-sm px-1 mb-2 sm:mb-3">
+                          وفر: <FormattedPrice value={book.originalPrice - book.price} />
+                        </p>
+                      )}
+                    </>
+                  );
+                })()}
               </div>
               
               <Button 


### PR DESCRIPTION
## Summary
- hide strikethrough price and savings when no discount exists
- display available price only

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a19c1640832aba61db4ac6af3a0e