### PR TITLE
Remove unused CSV import dialog

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -252,7 +252,6 @@ const DashboardAuthors = ({ authors, setAuthors }) => {
           </tbody>
         </table>
       </div>
-      <CsvImportDialog open={importOpen} onOpenChange={setImportOpen} onImport={handleImportBooks} />
     </motion.div>
   );
 };


### PR DESCRIPTION
## Summary
- remove reference to CsvImportDialog from dashboard author view

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874be4ecf90832aae4f804dcfe189ec