### PR TITLE
Fix sidebar overflow in dashboard

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -78,7 +78,7 @@ const DashboardSidebar = ({ dashboardSection, setDashboardSection, sidebarOpen, 
           </button>
         </div>
         
-        <nav className="space-y-1.5 flex-grow">
+        <nav className="space-y-1.5 flex-grow overflow-y-auto">
           {navItems.map(({ id, name, icon: IconComponent }) => (
             <button
               key={id}

--- a/src/index.css
+++ b/src/index.css
@@ -128,7 +128,8 @@
 }
 
 .sidebar-nav {
-  background: hsl(225 25% 18%); 
+  background: hsl(225 25% 18%);
+  overflow-y: auto;
 }
 .sidebar-nav .nav-item.active {
     background-color: hsl(var(--primary) / 0.9);


### PR DESCRIPTION
## Summary
- keep the dashboard sidebar scrollable so all items stay inside

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875f2245988832a9038f41ae751fd39