### PR TITLE
Add SEO metadata and sitemap

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,19 @@
 	<head>
 		<meta charset="UTF-8" />
 		<link rel="icon" type="image/svg+xml" href="/vite.svg" />
-		<meta name="generator" content="Hostinger Horizons" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>دار ملهمون للنشر والتوزيع</title>
+                <meta name="generator" content="Hostinger Horizons" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <meta name="description" content="مكتبة ملهمون لشراء الكتب الورقية والرقمية والاستماع للكتب الصوتية" />
+                <meta name="keywords" content="كتب, متجر كتب, دار نشر, كتب صوتية, كتب إلكترونية" />
+                <meta name="robots" content="index,follow" />
+                <link rel="canonical" href="https://www.molhemoon.com/" />
+                <meta property="og:title" content="دار ملهمون للنشر والتوزيع" />
+                <meta property="og:description" content="مكتبة ملهمون لشراء الكتب الورقية والرقمية والاستماع للكتب الصوتية" />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://www.molhemoon.com/" />
+                <meta property="og:image" content="/vite.svg" />
+                <meta name="twitter:card" content="summary_large_image" />
+                <title>دار ملهمون للنشر والتوزيع</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 	</head>
 	<body>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: /sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.molhemoon.com/</loc>
+  </url>
+  <url>
+    <loc>https://www.molhemoon.com/ebooks</loc>
+  </url>
+  <url>
+    <loc>https://www.molhemoon.com/audiobooks</loc>
+  </url>
+  <url>
+    <loc>https://www.molhemoon.com/cart</loc>
+  </url>
+  <url>
+    <loc>https://www.molhemoon.com/login</loc>
+  </url>
+</urlset>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import { toast } from '@/components/ui/use-toast.js';
 import Header from '@/components/Header.jsx';
 import Footer from '@/components/Footer.jsx';
 import Dashboard from '@/components/Dashboard.jsx';
+import SEO from '@/components/SEO.jsx';
 import AdminLoginPage from '@/pages/AdminLoginPage.jsx';
 import AuthPage from '@/pages/AuthPage.jsx';
 
@@ -290,22 +291,29 @@ const App = () => {
   };
   
   const MainLayout = ({ children, siteSettings }) => (
-    <div className="min-h-screen bg-slate-100 text-gray-800">
-      <Header
-        handleFeatureClick={handleFeatureClick}
-        cartItemCount={cart.reduce((sum, item) => sum + item.quantity, 0)}
-        isCustomerLoggedIn={isCustomerLoggedIn}
-        books={books}
-        categories={categoriesState}
-        siteSettings={siteSettings}
+    <>
+      <SEO
+        title={siteSettings.siteName}
+        description={siteSettings.description}
+        keywords="كتب, متجر كتب, كتب صوتية, كتب إلكترونية, دار نشر"
       />
-      {children}
-      <Footer
-        footerLinks={footerLinks}
-        handleFeatureClick={handleFeatureClick}
-        siteSettings={siteSettings}
-      />
-    </div>
+      <div className="min-h-screen bg-slate-100 text-gray-800">
+        <Header
+          handleFeatureClick={handleFeatureClick}
+          cartItemCount={cart.reduce((sum, item) => sum + item.quantity, 0)}
+          isCustomerLoggedIn={isCustomerLoggedIn}
+          books={books}
+          categories={categoriesState}
+          siteSettings={siteSettings}
+        />
+        {children}
+        <Footer
+          footerLinks={footerLinks}
+          handleFeatureClick={handleFeatureClick}
+          siteSettings={siteSettings}
+        />
+      </div>
+    </>
   );
 
   return (

--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+
+const SEO = ({ title, description, keywords }) => {
+  useEffect(() => {
+    if (title) {
+      document.title = title;
+    }
+    if (description) {
+      let tag = document.querySelector('meta[name="description"]');
+      if (!tag) {
+        tag = document.createElement('meta');
+        tag.setAttribute('name', 'description');
+        document.head.appendChild(tag);
+      }
+      tag.setAttribute('content', description);
+    }
+    if (keywords) {
+      let tag = document.querySelector('meta[name="keywords"]');
+      if (!tag) {
+        tag = document.createElement('meta');
+        tag.setAttribute('name', 'keywords');
+        document.head.appendChild(tag);
+      }
+      tag.setAttribute('content', keywords);
+    }
+  }, [title, description, keywords]);
+
+  return null;
+};
+
+export default SEO;


### PR DESCRIPTION
## Summary
- include SEO meta tags in `index.html`
- set up simple `<SEO>` helper component and use it in the layout
- provide `robots.txt` and `sitemap.xml` to help search engines index the site

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878d4d93bcc832aad3bbb446a339fcd