### PR TITLE
Add basic legal pages and routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,6 @@ Server side integrations for Stripe and PayPal are available. Set `STRIPE_SECRET
 - Data in the dashboard is persisted in Firebase. The optional PHP backend is only used for the Google Merchant import.
 - If you need to build the project for production, run `npm run build` (requires installed dependencies).
 - Category management forms still include a dropdown to select an icon from the `lucide-react` library.
+
+## Legal
+Placeholder documents for a privacy policy, terms of service and return policy are available in the `legal/` directory. Review and adapt them to comply with GDPR, CCPA and other relevant regulations.

--- a/legal/privacy_policy.md
+++ b/legal/privacy_policy.md
@@ -1,0 +1,6 @@
+# Privacy Policy
+
+This placeholder privacy policy describes how user data is collected and processed.
+The application aims to comply with the General Data Protection Regulation (GDPR)
+and the California Consumer Privacy Act (CCPA). Review and update this file to
+match your specific business requirements and local laws.

--- a/legal/return_policy.md
+++ b/legal/return_policy.md
@@ -1,0 +1,4 @@
+# Return Policy
+
+This placeholder return policy explains how customers can return products.
+Update the contents based on your business processes and legal obligations.

--- a/legal/terms_of_service.md
+++ b/legal/terms_of_service.md
@@ -1,0 +1,6 @@
+# Terms of Service
+
+These placeholder terms outline acceptable use of the bookstore application.
+They are provided as a starting point and do not constitute legal advice.
+Customize these terms and consult with a professional to ensure compliance with
+local and international regulations.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,9 @@ import ListenSamplePage from '@/pages/ListenSamplePage.jsx';
 import EbookReaderPage from '@/pages/EbookReaderPage.jsx';
 import AudiobookPlayerPage from '@/pages/AudiobookPlayerPage.jsx';
 import SearchResultsPage from '@/pages/SearchResultsPage.jsx';
+import PrivacyPolicyPage from '@/pages/PrivacyPolicyPage.jsx';
+import TermsOfServicePage from '@/pages/TermsOfServicePage.jsx';
+import ReturnPolicyPage from '@/pages/ReturnPolicyPage.jsx';
 import AddToCartDialog from '@/components/AddToCartDialog.jsx';
 
 import { sellers as initialSellers, customers as initialCustomers, footerLinks, siteSettings as initialSiteSettings, paymentMethods as initialPaymentMethods } from '@/data/siteData.js';
@@ -406,6 +409,9 @@ const App = () => {
               <Route path="/reader/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><EbookReaderPage books={books} /></PageLayout></MainLayout>} />
               <Route path="/listen/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><ListenSamplePage books={books} /></PageLayout></MainLayout>} />
               <Route path="/player/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><AudiobookPlayerPage books={books} /></PageLayout></MainLayout>} />
+              <Route path="/privacy-policy" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><PrivacyPolicyPage /></PageLayout></MainLayout>} />
+              <Route path="/terms-of-service" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><TermsOfServicePage /></PageLayout></MainLayout>} />
+              <Route path="/return-policy" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><ReturnPolicyPage /></PageLayout></MainLayout>} />
               <Route path="*" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><NotFoundPage /></PageLayout></MainLayout>} />
             </Routes>
         </AnimatePresence>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -89,8 +89,9 @@ const Footer = ({ footerLinks, handleFeatureClick, siteSettings = {} }) => {
         <div className="border-t border-slate-700/50 pt-5 sm:pt-6 flex flex-col sm:flex-row justify-between items-center text-[10px] sm:text-xs text-white">
           <p>جميع الحقوق محفوظة © {new Date().getFullYear()} {siteSettings.siteName || 'ملهمون'}</p>
           <div className="flex space-x-2.5 sm:space-x-3 rtl:space-x-reverse mt-2 sm:mt-0">
-            <a href="#" className="hover:text-blue-200" onClick={(e) => {e.preventDefault(); handleFeatureClick('privacy-policy')}}>سياسة الخصوصية</a>
-            <a href="#" className="hover:text-blue-200" onClick={(e) => {e.preventDefault(); handleFeatureClick('terms-of-use')}}>شروط الاستخدام</a>
+            <Link to="/privacy-policy" className="hover:text-blue-200">سياسة الخصوصية</Link>
+            <Link to="/terms-of-service" className="hover:text-blue-200">شروط الاستخدام</Link>
+            <Link to="/return-policy" className="hover:text-blue-200">سياسة الإرجاع</Link>
           </div>
         </div>
       </div>

--- a/src/pages/PrivacyPolicyPage.jsx
+++ b/src/pages/PrivacyPolicyPage.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const PrivacyPolicyPage = () => (
+  <div className="max-w-screen-md mx-auto p-6 bg-white rounded-lg shadow mt-6">
+    <motion.h1
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="text-2xl font-bold mb-4"
+    >
+      سياسة الخصوصية
+    </motion.h1>
+    <p className="text-sm leading-6 text-gray-700">
+      يتم توفير هذه الصفحة كنموذج عام لشرح كيفية جمع البيانات واستخدامها. يجب
+      مراجعة محتوى السياسة ليتوافق مع متطلبات اللوائح مثل GDPR وCCPA.
+    </p>
+  </div>
+);
+
+export default PrivacyPolicyPage;

--- a/src/pages/ReturnPolicyPage.jsx
+++ b/src/pages/ReturnPolicyPage.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const ReturnPolicyPage = () => (
+  <div className="max-w-screen-md mx-auto p-6 bg-white rounded-lg shadow mt-6">
+    <motion.h1
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="text-2xl font-bold mb-4"
+    >
+      سياسة الإرجاع
+    </motion.h1>
+    <p className="text-sm leading-6 text-gray-700">
+      تحتوي هذه الصفحة على إرشادات عامة حول كيفية إرجاع المنتجات. يجب تخصيص
+      التفاصيل بما يتوافق مع سياسات المتجر والقوانين السارية.
+    </p>
+  </div>
+);
+
+export default ReturnPolicyPage;

--- a/src/pages/TermsOfServicePage.jsx
+++ b/src/pages/TermsOfServicePage.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const TermsOfServicePage = () => (
+  <div className="max-w-screen-md mx-auto p-6 bg-white rounded-lg shadow mt-6">
+    <motion.h1
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="text-2xl font-bold mb-4"
+    >
+      شروط الاستخدام
+    </motion.h1>
+    <p className="text-sm leading-6 text-gray-700">
+      هذه البنود وضعت كمثال لتحديد حقوق وواجبات المستخدمين. يرجى تعديلها بما
+      يتوافق مع متطلبات عملكم والقوانين المحلية والدولية.
+    </p>
+  </div>
+);
+
+export default TermsOfServicePage;


### PR DESCRIPTION
## Summary
- add placeholder privacy, terms and return policies
- create legal pages and link them in the footer
- update router with new routes
- mention legal docs in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6878d66e58b8832a99cdc3a2cb0b5ff6