### PR TITLE
Add scroll reset on page navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,7 @@ import PrivacyPolicyPage from '@/pages/PrivacyPolicyPage.jsx';
 import TermsOfServicePage from '@/pages/TermsOfServicePage.jsx';
 import ReturnPolicyPage from '@/pages/ReturnPolicyPage.jsx';
 import AddToCartDialog from '@/components/AddToCartDialog.jsx';
+import ScrollToTop from '@/components/ScrollToTop.jsx';
 
 import { sellers as initialSellers, customers as initialCustomers, footerLinks, siteSettings as initialSiteSettings, paymentMethods as initialPaymentMethods } from '@/data/siteData.js';
 import api from '@/lib/api.js';
@@ -345,6 +346,7 @@ const App = () => {
 
   return (
     <Router>
+      <ScrollToTop />
       <div className="font-sans" dir="rtl">
         <AnimatePresence mode="wait">
           <Routes>

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
## Summary
- add `ScrollToTop` component that scrolls to the top on route change
- use the new component inside `App.jsx` router

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881f96f8cb0832a8581cf4a3b8cfa2b