### PR TITLE
Implement basic chat support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,6 +68,7 @@ const App = () => {
   const [categoriesState, setCategoriesState] = useState([]);
   const [orders, setOrders] = useState(() => JSON.parse(localStorage.getItem('orders') || '[]'));
   const [payments, setPayments] = useState(() => JSON.parse(localStorage.getItem('payments') || '[]'));
+  const [messages, setMessages] = useState([]);
   const [paymentMethods, setPaymentMethods] = useState(() => {
     const stored = localStorage.getItem('paymentMethods');
     return stored ? JSON.parse(stored) : initialPaymentMethods;
@@ -111,9 +112,11 @@ const App = () => {
     if (storedSettings) setSiteSettingsState(JSON.parse(storedSettings));
     const storedFeatures = localStorage.getItem('features');
     if (storedFeatures) setFeatures(JSON.parse(storedFeatures));
+    const storedMessages = localStorage.getItem('messages');
+    if (storedMessages) setMessages(JSON.parse(storedMessages));
     (async () => {
       try {
-        const [b, a, c, s, o, pay, methods, p, u, sliders, banners, feats, sellData, branchData, custData, subs] = await Promise.all([
+        const [b, a, c, s, o, pay, methods, p, u, sliders, banners, feats, sellData, branchData, custData, subs, msgs] = await Promise.all([
           api.getBooks(),
           api.getAuthors(),
           api.getCategories(),
@@ -130,6 +133,7 @@ const App = () => {
           api.getBranches(),
           api.getCustomers(),
           api.getSubscriptions(),
+          api.getMessages(),
         ]);
         setBooks(b);
         setAuthors(a);
@@ -147,6 +151,7 @@ const App = () => {
         setBranches(branchData);
         setCustomers(custData);
         setSubscriptions(subs);
+        setMessages(msgs);
         const sales = pay.reduce((sum, item) => sum + (Number(item.amount) || 0), 0);
         setDashboardStatsState([
           { title: 'إجمالي الكتب', value: b.length, icon: BookOpen, color: 'bg-blue-500' },
@@ -219,6 +224,10 @@ const App = () => {
   useEffect(() => {
     localStorage.setItem('features', JSON.stringify(features));
   }, [features]);
+
+  useEffect(() => {
+    localStorage.setItem('messages', JSON.stringify(messages));
+  }, [messages]);
 
   useEffect(() => {
     const sales = payments.reduce((sum, p) => sum + (Number(p.amount) || 0), 0);
@@ -401,6 +410,8 @@ const App = () => {
                     setSubscriptions={setSubscriptions}
                     users={users}
                     setUsers={setUsers}
+                    messages={messages}
+                    setMessages={setMessages}
                     siteSettings={siteSettingsState}
                     setSiteSettings={setSiteSettingsState}
                     sliders={heroSlidesState}

--- a/src/components/ChatWidget.jsx
+++ b/src/components/ChatWidget.jsx
@@ -3,30 +3,55 @@ import { MessageCircle, Send, X } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog.jsx';
 import { Button } from '@/components/ui/button.jsx';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { collection, onSnapshot, addDoc, query, where, orderBy } from 'firebase/firestore';
+import { db } from '@/lib/firebase.js';
+import api from '@/lib/api.js';
 
 const ChatWidget = ({ open, onOpenChange, contact = { type: 'admin', name: 'الدعم' } }) => {
-  const contactKey = `${contact.type}_${contact.name}`;
-  const [messages, setMessages] = useState(() => {
-    try {
-      return JSON.parse(localStorage.getItem(`chat_${contactKey}`)) || [];
-    } catch {
-      return [];
-    }
-  });
+  const [messages, setMessages] = useState([]);
   const [text, setText] = useState('');
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [userId, setUserId] = useState('');
 
   useEffect(() => {
-    localStorage.setItem(`chat_${contactKey}`, JSON.stringify(messages));
-  }, [messages, contactKey]);
+    const id = localStorage.getItem('currentUserId');
+    if (localStorage.getItem('customerLoggedIn') === 'true' && id) {
+      setUserId(id);
+      api.getUser(id).then(u => {
+        if (u) {
+          setName(u.name || '');
+          setEmail(u.email || '');
+        }
+      });
+    }
+  }, []);
 
-  const send = () => {
+  useEffect(() => {
+    if (!userId && !email) return;
+    const q = query(
+      collection(db, 'messages'),
+      where(userId ? 'userId' : 'email', '==', userId || email),
+      orderBy('createdAt', 'asc')
+    );
+    const unsub = onSnapshot(q, snap => {
+      setMessages(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+    });
+    return () => unsub();
+  }, [userId, email]);
+
+  const send = async () => {
     const trimmed = text.trim();
     if (!trimmed) return;
-    setMessages(prev => [...prev, { id: Date.now(), sender: 'user', text: trimmed }]);
+    if (!name || !email) return;
+    await addDoc(collection(db, 'messages'), {
+      userId: userId || null,
+      name,
+      email,
+      text: trimmed,
+      createdAt: new Date(),
+    });
     setText('');
-    setTimeout(() => {
-      setMessages(prev => [...prev, { id: Date.now() + 1, sender: 'contact', text: 'شكرًا لتواصلك! سيتم الرد قريبًا.' }]);
-    }, 800);
   };
 
   return (
@@ -40,23 +65,50 @@ const ChatWidget = ({ open, onOpenChange, contact = { type: 'admin', name: 'ال
         </div>
         <div className="p-3 space-y-2 h-64 overflow-y-auto bg-gray-50 text-sm">
           {messages.map(m => (
-            <div key={m.id} className={`flex ${m.sender === 'user' ? 'justify-end' : 'justify-start'}`}>
-              <div className={`${m.sender === 'user' ? 'bg-blue-600 text-white' : 'bg-white text-gray-800'} rounded-lg px-3 py-1 max-w-[70%]`}>{m.text}</div>
+            <div key={m.id} className="space-y-1">
+              <div className="flex justify-end">
+                <div className="bg-blue-600 text-white rounded-lg px-3 py-1 max-w-[70%]">{m.text}</div>
+              </div>
+              {m.reply && (
+                <div className="flex justify-start">
+                  <div className="bg-white text-gray-800 rounded-lg px-3 py-1 max-w-[70%]">{m.reply}</div>
+                </div>
+              )}
             </div>
           ))}
         </div>
-        <div className="p-3 border-t bg-white flex gap-2">
-          <input
-            type="text"
-            value={text}
-            onChange={e => setText(e.target.value)}
-            className="flex-grow border rounded px-2 py-1 text-sm focus:outline-none"
-            placeholder="اكتب رسالتك"
-          />
-          <Button size="sm" className="h-8 bg-blue-600 text-white" onClick={send}>
-            <Send className="w-4 h-4 ml-1 rtl:mr-1 rtl:ml-0" />
-            إرسال
-          </Button>
+        <div className="p-3 border-t bg-white flex flex-col gap-2">
+          {!userId && (
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className="border rounded px-2 py-1 text-sm mb-2 focus:outline-none"
+              placeholder="اسمك"
+            />
+          )}
+          {!userId && (
+            <input
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              className="border rounded px-2 py-1 text-sm mb-2 focus:outline-none"
+              placeholder="بريدك الإلكتروني"
+            />
+          )}
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={text}
+              onChange={e => setText(e.target.value)}
+              className="flex-grow border rounded px-2 py-1 text-sm focus:outline-none"
+              placeholder="اكتب رسالتك"
+            />
+            <Button size="sm" className="h-8 bg-blue-600 text-white" onClick={send}>
+              <Send className="w-4 h-4 ml-1 rtl:mr-1 rtl:ml-0" />
+              إرسال
+            </Button>
+          </div>
         </div>
       </DialogContent>
       {!open && (

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -33,7 +33,8 @@ import {
   Zap,
   Headphones,
   Boxes,
-  MapPin
+  MapPin,
+  MessageCircle
 } from 'lucide-react';
 import * as AllIcons from 'lucide-react';
 import { Input } from '@/components/ui/input.jsx';
@@ -71,6 +72,7 @@ const DashboardSidebar = ({ dashboardSection, setDashboardSection, sidebarOpen, 
     { id: 'payment-methods', name: 'طرق الدفع', icon: Wallet },
     { id: 'plans', name: 'الخطط', icon: DollarSign },
     { id: 'subscriptions', name: 'العضويات', icon: Crown },
+    { id: 'messages', name: 'الرسائل', icon: MessageCircle },
     { id: 'features', name: 'المميزات', icon: Zap },
     { id: 'sliders', name: 'السلايدر', icon: Image },
     { id: 'banners', name: 'البانرات', icon: Image },
@@ -1673,6 +1675,64 @@ const DashboardFeatures = ({ features, setFeatures }) => {
   );
 };
 
+const DashboardMessages = ({ messages, setMessages }) => {
+  const [replyMap, setReplyMap] = useState({});
+
+  const handleReply = async (id) => {
+    const text = replyMap[id];
+    if (!text) return;
+    try {
+      const updated = await api.updateMessage(id, { reply: text });
+      setMessages((prev) => prev.map((m) => (m.id === id ? updated : m)));
+      setReplyMap((prev) => ({ ...prev, [id]: '' }));
+      toast({ title: 'تم إرسال الرد' });
+    } catch {
+      toast({ title: 'حدث خطأ أثناء الإرسال', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <motion.div className="space-y-5" initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+      <h2 className="text-2xl font-semibold text-gray-700 mb-3">رسائل العملاء</h2>
+      <div className="dashboard-card rounded-xl shadow-lg overflow-hidden bg-white">
+        <table className="w-full min-w-[400px]">
+          <thead className="bg-slate-50">
+            <tr>
+              <th className="px-5 py-3.5 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">الاسم</th>
+              <th className="px-5 py-3.5 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">البريد</th>
+              <th className="px-5 py-3.5 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">الرسالة</th>
+              <th className="px-5 py-3.5 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">الرد</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200">
+            {messages.map((m) => (
+              <tr key={m.id} className="hover:bg-slate-50/50 transition-colors">
+                <td className="px-5 py-3 whitespace-nowrap text-sm text-gray-700">{m.name}</td>
+                <td className="px-5 py-3 whitespace-nowrap text-sm text-gray-700">{m.email}</td>
+                <td className="px-5 py-3 whitespace-nowrap text-sm text-gray-700">{m.text}</td>
+                <td className="px-5 py-3 whitespace-nowrap text-sm">
+                  {m.reply ? (
+                    m.reply
+                  ) : (
+                    <div className="flex items-center space-x-2 rtl:space-x-reverse">
+                      <input
+                        className="border rounded px-2 py-1 text-sm"
+                        value={replyMap[m.id] || ''}
+                        onChange={(e) => setReplyMap((prev) => ({ ...prev, [m.id]: e.target.value }))}
+                      />
+                      <Button size="sm" onClick={() => handleReply(m.id)}>إرسال</Button>
+                    </div>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </motion.div>
+  );
+};
+
 const OrderDetailsDialog = ({ open, onOpenChange, order, onUpdateStatus, onDelete }) => {
   if (!order) return null;
   const statuses = ['قيد المعالجة', 'قيد الشحن', 'تم التوصيل', 'ملغي'];
@@ -2728,7 +2788,7 @@ const PlaceholderSection = ({ sectionName, handleFeatureClick }) => (
 );
 
 
-const Dashboard = ({ dashboardStats, books, authors, sellers, branches, customers, categories, orders, payments, paymentMethods, plans, subscriptions, users, dashboardSection, setDashboardSection, handleFeatureClick, setBooks, setAuthors, setSellers, setBranches, setCustomers, setCategories, setOrders, setPayments, setPaymentMethods, setPlans, setSubscriptions, setUsers, siteSettings, setSiteSettings, sliders, setSliders, banners, setBanners, features, setFeatures }) => {
+const Dashboard = ({ dashboardStats, books, authors, sellers, branches, customers, categories, orders, payments, paymentMethods, plans, subscriptions, users, messages, dashboardSection, setDashboardSection, handleFeatureClick, setBooks, setAuthors, setSellers, setBranches, setCustomers, setCategories, setOrders, setPayments, setPaymentMethods, setPlans, setSubscriptions, setUsers, setMessages, siteSettings, setSiteSettings, sliders, setSliders, banners, setBanners, features, setFeatures }) => {
   const sectionTitles = {
     overview: 'نظرة عامة',
     books: 'إدارة الكتب',
@@ -2744,6 +2804,7 @@ const Dashboard = ({ dashboardStats, books, authors, sellers, branches, customer
     'payment-methods': 'طرق الدفع',
     plans: 'خطط الاشتراك',
     subscriptions: 'العضويات',
+    messages: 'الرسائل',
     features: 'المميزات',
     sliders: 'السلايدر',
     banners: 'البانرات',
@@ -2805,6 +2866,9 @@ const Dashboard = ({ dashboardStats, books, authors, sellers, branches, customer
             customers={customers}
             plans={plans}
           />
+        )}
+        {dashboardSection === 'messages' && (
+          <DashboardMessages messages={messages} setMessages={setMessages} />
         )}
         {dashboardSection === 'features' && <DashboardFeatures features={features} setFeatures={setFeatures} />}
         {dashboardSection === 'sliders' && <DashboardSliders sliders={sliders} setSliders={setSliders} />}


### PR DESCRIPTION
## Summary
- add Firebase helpers for user support messages
- update `ChatWidget` to send/receive chat messages
- store and fetch messages in `App`
- show messages in the admin dashboard

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836e416024832a995152995fdb59c0