### PR TITLE
Add order tracking page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import CheckoutPage from '@/pages/CheckoutPage.jsx';
 import UserProfilePage from '@/pages/UserProfilePage.jsx';
 import OrderDetailsPage from '@/pages/OrderDetailsPage.jsx';
 import DashboardOrderDetailsPage from '@/pages/DashboardOrderDetailsPage.jsx';
+import TrackOrderPage from '@/pages/TrackOrderPage.jsx';
 import NotFoundPage from '@/pages/NotFoundPage.jsx';
 import AudiobookPage from '@/pages/AudiobookPage.jsx';
 import EbookPage from '@/pages/EbookPage.jsx';
@@ -472,6 +473,7 @@ const App = () => {
               />
               <Route path="/profile" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><UserProfilePage handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
               <Route path="/orders/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><OrderDetailsPage /></PageLayout></MainLayout>} />
+              <Route path="/track-order" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><TrackOrderPage /></PageLayout></MainLayout>} />
               <Route path="/ebooks" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><EbookPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} wishlist={wishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
               <Route path="/audiobooks" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><AudiobookPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} wishlist={wishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
               <Route path="/read/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><ReadSamplePage books={books} /></PageLayout></MainLayout>} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -211,7 +211,7 @@ const Header = ({ handleFeatureClick, cartItemCount, isCustomerLoggedIn, books =
   <span>كتاب مسموع</span>
 </Link>
             <span className="mx-2">|</span>
-           <button onClick={() => handleFeatureClick('track-order-top')} className="hover:text-blue-200">{t('trackOrder')}</button>
+           <Link to="/track-order" className="hover:text-blue-200">{t('trackOrder')}</Link>
             <span className="mx-2">|</span>
            <button onClick={() => handleFeatureClick('download-app-top')} className="hover:text-blue-200">{t('downloadApp')}</button>
             <span className="mx-2">|</span>

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -16,7 +16,7 @@ const TopBar = ({ handleFeatureClick, isLoggedIn }) => {
     { icon: BookOpen, text: 'كتاب إلكتروني', action: 'ebook-top', link: '/category/ebooks' }, // Assuming a category for ebooks or similar
     { icon: Headphones, text: 'كتاب مسموع', action: 'audiobook-top', link: '/audiobooks' },
     { icon: Tag, text: 'قائمة الرغبات', action: 'wishlist-top', link: '/profile?tab=wishlist' },
-    { icon: Box, text: t('trackOrder'), action: 'track-order-top', link: '/profile?tab=orders' },
+    { icon: Box, text: t('trackOrder'), action: 'track-order-top', link: '/track-order' },
     { icon: Download, text: t('downloadApp'), action: 'download-app-top' },
     { icon: HelpCircle, text: t('help'), action: 'help-top' },
     { icon: MapPin, text: t('locations'), action: 'locations-top' },

--- a/src/pages/TrackOrderPage.jsx
+++ b/src/pages/TrackOrderPage.jsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { Input } from '@/components/ui/input.jsx';
+import { Button } from '@/components/ui/button.jsx';
+import api from '@/lib/api.js';
+
+const TrackOrderPage = () => {
+  const [orderId, setOrderId] = useState('');
+  const [order, setOrder] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    setOrder(null);
+    try {
+      const data = await api.getOrder(orderId.trim());
+      if (!data) {
+        setError('لم يتم العثور على الطلب');
+      } else {
+        setOrder(data);
+      }
+    } catch (err) {
+      setError('حدث خطأ أثناء البحث عن الطلب');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const steps = ['قيد المعالجة', 'قيد الشحن', 'تم التوصيل'];
+  const current = order ? steps.indexOf(order.status) : -1;
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <motion.h1
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="text-2xl sm:text-3xl font-bold text-gray-800 mb-6 text-center"
+      >
+        تتبع الطلب
+      </motion.h1>
+      <form onSubmit={handleSubmit} className="max-w-md mx-auto space-y-4">
+        <Input
+          placeholder="أدخل رقم الطلب"
+          value={orderId}
+          onChange={(e) => setOrderId(e.target.value)}
+        />
+        <Button type="submit" className="w-full bg-blue-600 hover:bg-blue-700" disabled={loading}>
+          {loading ? 'جاري البحث...' : 'بحث'}
+        </Button>
+      </form>
+      {error && <p className="mt-4 text-center text-red-600">{error}</p>}
+      {order && (
+        <div className="mt-8 bg-white p-6 rounded-lg shadow max-w-md mx-auto space-y-4">
+          <p className="text-sm text-gray-600">رقم الطلب: <span className="font-semibold">{order.id}</span></p>
+          <div className="flex justify-between items-center">
+            {steps.map((s, idx) => (
+              <div key={s} className="flex-1 text-center">
+                <div className={`w-6 h-6 mx-auto rounded-full text-xs flex items-center justify-center ${idx <= current ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-500'}`}>{idx + 1}</div>
+                <p className="mt-1 text-xs">{s}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TrackOrderPage;


### PR DESCRIPTION
## Summary
- add `TrackOrderPage` for order tracking
- expose new page via `/track-order` route
- update header and topbar links to use the new page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688376769e54832a846fd4c0f26f6505