### PR TITLE
Update audiobook page package section

### DIFF
--- a/src/pages/AudiobookPage.jsx
+++ b/src/pages/AudiobookPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Check, Award, Star, Play, Clock, Headphones } from 'lucide-react';
 import { Button } from '@/components/ui/button.jsx';
+import { toast } from '@/components/ui/use-toast.js';
 import api from '@/lib/api.js';
 
 const AudiobookPage = () => {
@@ -138,20 +139,26 @@ const AudiobookPage = () => {
           {plans.map((plan, index) => (
             <motion.div
               key={plan.id}
-              className="bg-white rounded-2xl shadow-lg border border-gray-200 p-6"
+              className={`bg-white rounded-2xl shadow-lg border p-6 ${plan.featured ? 'border-orange-400' : 'border-gray-200'}`}
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, amount: 0.2 }}
               transition={{ duration: 0.4, delay: index * 0.1 }}
             >
               <div className="text-center mb-6">
-                <h3 className="text-xl font-bold text-gray-900 mb-1">{plan.name}</h3>
+                <h3 className="text-xl font-bold text-gray-900 mb-1">
+                  {plan.name}
+                  {plan.featured && (
+                    <span className="ml-2 rtl:mr-2 text-xs text-orange-600 font-semibold">الأكثر شيوعاً</span>
+                  )}
+                </h3>
                 <div className="mb-4">
                   <span className="text-3xl font-bold text-gray-900">{plan.price}</span>
                   <span className="text-gray-600 text-sm mr-1">{plan.duration} يوم</span>
                 </div>
               </div>
-              <Button className="w-full bg-[#E4E6FF] hover:bg-[#d6d8f2] text-[#315dfb] border border-[#E4E6FF]">
+              <p className="text-sm text-gray-700 mb-6 text-center" dangerouslySetInnerHTML={{ __html: plan.description }} />
+              <Button className="w-full bg-[#E4E6FF] hover:bg-[#d6d8f2] text-[#315dfb] border border-[#E4E6FF]" onClick={() => toast({ title: `تم اختيار ${plan.name}` })}>
                 اختر باقتك
               </Button>
             </motion.div>


### PR DESCRIPTION
## Summary
- show plan description and "popular" tag on Audiobook page
- handle toast feedback when selecting an audio plan

## Testing
- `npm test --silent`
- `npm run build --silent` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883824f0b88832aa39b00fd381e19e0