### PR TITLE
Add translation & SEO settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -349,9 +349,9 @@ const App = () => {
   const MainLayout = ({ children, siteSettings }) => (
     <>
       <SEO
-        title={siteSettings.siteName}
-        description={siteSettings.description}
-        keywords="كتب, متجر كتب, كتب صوتية, كتب إلكترونية, دار نشر"
+        title={siteSettings.seoTitle || siteSettings.siteName}
+        description={siteSettings.seoDescription || siteSettings.description}
+        keywords={siteSettings.seoKeywords || 'كتب, متجر كتب, كتب صوتية, كتب إلكترونية, دار نشر'}
       />
       <div className="min-h-screen bg-slate-100 text-gray-800">
         <Header

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -2234,8 +2234,8 @@ const BookForm = ({ book, onSubmit, onCancel, authors, categories, defaultType =
   });
 
   const handleChange = (e) => {
-    const { name, value } = e.target;
-    setFormData(prev => ({ ...prev, [name]: value }));
+    const { name, type, value, checked } = e.target;
+    setFormData(prev => ({ ...prev, [name]: type === 'checkbox' ? checked : value }));
   };
 
   const handleSubmit = (e) => {
@@ -2649,11 +2649,18 @@ const DashboardBooks = ({ books, setBooks, authors, categories, setCategories, h
 
 
 const DashboardSettings = ({ siteSettings, setSiteSettings }) => {
-  const [formData, setFormData] = useState(siteSettings);
+  const [formData, setFormData] = useState({
+    seoTitle: '',
+    seoDescription: '',
+    seoKeywords: '',
+    translationApiKey: '',
+    autoTranslate: false,
+    ...siteSettings,
+  });
 
   const handleChange = (e) => {
-    const { name, value } = e.target;
-    setFormData(prev => ({ ...prev, [name]: value }));
+    const { name, type, value, checked } = e.target;
+    setFormData(prev => ({ ...prev, [name]: type === 'checkbox' ? checked : value }));
   };
 
   const handleSubmit = async (e) => {
@@ -2724,6 +2731,26 @@ const DashboardSettings = ({ siteSettings, setSiteSettings }) => {
           <div className="md:col-span-2">
             <Label htmlFor="languages">اللغات المتاحة (افصل بينها بفاصلة)</Label>
             <Input id="languages" name="languages" value={formData.languages} onChange={handleChange} />
+          </div>
+          <div>
+            <Label htmlFor="translationApiKey">مفتاح الترجمة</Label>
+            <Input id="translationApiKey" name="translationApiKey" value={formData.translationApiKey} onChange={handleChange} />
+          </div>
+          <div className="flex items-center space-x-2 rtl:space-x-reverse">
+            <input id="autoTranslate" name="autoTranslate" type="checkbox" checked={formData.autoTranslate} onChange={handleChange} className="w-4 h-4" />
+            <Label htmlFor="autoTranslate" className="!mb-0">تفعيل الترجمة التلقائية</Label>
+          </div>
+          <div>
+            <Label htmlFor="seoTitle">عنوان SEO</Label>
+            <Input id="seoTitle" name="seoTitle" value={formData.seoTitle} onChange={handleChange} />
+          </div>
+          <div>
+            <Label htmlFor="seoDescription">وصف SEO</Label>
+            <Textarea id="seoDescription" name="seoDescription" value={formData.seoDescription} onChange={handleChange} rows={2} />
+          </div>
+          <div>
+            <Label htmlFor="seoKeywords">كلمات SEO</Label>
+            <Input id="seoKeywords" name="seoKeywords" value={formData.seoKeywords} onChange={handleChange} />
           </div>
           <div className="md:col-span-2 border-t pt-4">
             <h4 className="font-semibold mb-2">إعدادات الدفع</h4>

--- a/src/data/siteData.js
+++ b/src/data/siteData.js
@@ -335,7 +335,12 @@ export const siteSettings = {
   stripePublicKey: import.meta.env.VITE_STRIPE_PUBLIC_KEY || '',
   stripeSecretKey: '',
   paypalClientId: import.meta.env.VITE_PAYPAL_CLIENT_ID || '',
-  paypalSecret: ''
+  paypalSecret: '',
+  translationApiKey: '',
+  autoTranslate: false,
+  seoTitle: '',
+  seoDescription: '',
+  seoKeywords: ''
 };
 
 export const paymentMethods = [

--- a/src/lib/translate.js
+++ b/src/lib/translate.js
@@ -1,0 +1,7 @@
+export async function translate(text, targetLang) {
+  const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=${targetLang}&dt=t&q=${encodeURIComponent(text)}`;
+  const response = await fetch(url);
+  if (!response.ok) return text;
+  const data = await response.json();
+  return data[0].map(t => t[0]).join('');
+}


### PR DESCRIPTION
## Summary
- add translation and SEO fields to site data
- expose controls for these fields in dashboard settings
- provide SEO defaults in App layout
- add helper for automatic translation

## Testing
- `npm run build` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6883853bec34832a8544b1d2eae5c8b1