### PR TITLE
Fix profile page access control

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -471,7 +471,20 @@ const App = () => {
                   )
                 }
               />
-              <Route path="/profile" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><UserProfilePage handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
+              <Route
+                path="/profile"
+                element={
+                  isCustomerLoggedIn ? (
+                    <MainLayout siteSettings={siteSettingsState}>
+                      <PageLayout>
+                        <UserProfilePage handleFeatureClick={handleFeatureClick} />
+                      </PageLayout>
+                    </MainLayout>
+                  ) : (
+                    <Navigate to="/login" />
+                  )
+                }
+              />
               <Route path="/orders/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><OrderDetailsPage /></PageLayout></MainLayout>} />
               <Route path="/track-order" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><TrackOrderPage /></PageLayout></MainLayout>} />
               <Route path="/ebooks" element={<MainLayout siteSettings={siteSettingsState}><PageLayout><EbookPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} wishlist={wishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />

--- a/src/lib/firebaseApi.js
+++ b/src/lib/firebaseApi.js
@@ -99,6 +99,17 @@ const firebaseApi = {
   deleteUser: (id) => deleteFromCollection('users', id),
   getUser: (id) => getDocById('users', id),
 
+  // User specific subcollections
+  getUserAddresses: (userId) => getCollection(`users/${userId}/addresses`),
+  addUserAddress: (userId, data) => addToCollection(`users/${userId}/addresses`, data),
+  updateUserAddress: (userId, id, data) => updateCollection(`users/${userId}/addresses`, id, data),
+  deleteUserAddress: (userId, id) => deleteFromCollection(`users/${userId}/addresses`, id),
+
+  getUserPaymentMethods: (userId) => getCollection(`users/${userId}/payment_methods`),
+  addUserPaymentMethod: (userId, data) => addToCollection(`users/${userId}/payment_methods`, data),
+  updateUserPaymentMethod: (userId, id, data) => updateCollection(`users/${userId}/payment_methods`, id, data),
+  deleteUserPaymentMethod: (userId, id) => deleteFromCollection(`users/${userId}/payment_methods`, id),
+
   getSliders: () => getCollection('sliders'),
   addSlider: (data) => addToCollection('sliders', data),
   updateSlider: (id, data) => updateCollection('sliders', id, data),


### PR DESCRIPTION
## Summary
- restrict `/profile` route to logged-in customers
- expose address and payment subcollections in Firebase helper
- load real user data in the profile page
- persist addresses and payment methods to Firestore

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885e3931270832a9be822fdd57cc15f