### PR TITLE
Fix missing languages export

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { languages } from '@/lib/languageContext.jsx';
+import { defaultLanguages as languages } from '@/lib/languageContext.jsx';
 import api from '@/lib/api.js';
 import FormattedPrice from './FormattedPrice.jsx';
 import { motion } from 'framer-motion';


### PR DESCRIPTION
## Summary
- import defaultLanguages as languages in Dashboard

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885f2092f70832a89f0eb93baac999c