### PR TITLE
Link plans to payment with trial

### DIFF
--- a/src/components/SubscriptionDialog.jsx
+++ b/src/components/SubscriptionDialog.jsx
@@ -6,6 +6,7 @@ import { ChevronLeft, X } from 'lucide-react';
 import FormattedPrice from './FormattedPrice.jsx';
 import api from '@/lib/api.js';
 import { toast } from '@/components/ui/use-toast.js';
+import { purchasePlan } from '@/lib/subscriptionUtils.js';
 
 const SubscriptionDialog = ({ open, onOpenChange, book, onAddToCart }) => {
   const [plans, setPlans] = useState([]);
@@ -23,7 +24,7 @@ const SubscriptionDialog = ({ open, onOpenChange, book, onAddToCart }) => {
   const handleSubscribe = async () => {
     if (!plans.length) return;
     try {
-      await api.addSubscription({ customer_id: 1, plan_id: plans[0].id });
+      await purchasePlan(api, plans[0]);
       toast({ title: 'تم الاشتراك بنجاح!' });
       onOpenChange(false);
     } catch (e) {

--- a/src/lib/subscriptionUtils.js
+++ b/src/lib/subscriptionUtils.js
@@ -1,0 +1,29 @@
+export async function purchasePlan(api, plan, paymentMethodId = 1) {
+  const customerId = localStorage.getItem('currentUserId') || 1;
+  const now = new Date();
+  const startDate = now.toISOString();
+  const endDate = new Date(now.getTime() + plan.duration * 24 * 60 * 60 * 1000).toISOString();
+  const subData = {
+    customer_id: customerId,
+    plan_id: plan.id,
+    start_date: startDate,
+    end_date: endDate,
+    status: 'نشط',
+  };
+  if (!localStorage.getItem('trialUsed')) {
+    subData.trial_end = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    localStorage.setItem('trialUsed', 'true');
+  }
+  const subscription = await api.addSubscription(subData);
+  await api.addPayment({
+    customer_id: customerId,
+    order_id: null,
+    subscription_id: subscription.id,
+    payment_method_id: paymentMethodId,
+    coupon_id: null,
+    amount: plan.price,
+    status: subData.trial_end ? 'pending' : 'paid'
+  });
+  return subscription;
+}
+

--- a/src/pages/AudiobookPage.jsx
+++ b/src/pages/AudiobookPage.jsx
@@ -4,6 +4,7 @@ import { Check, Award, Star, Play, Clock, Headphones } from 'lucide-react';
 import { Button } from '@/components/ui/button.jsx';
 import { toast } from '@/components/ui/use-toast.js';
 import api from '@/lib/api.js';
+import { purchasePlan } from '@/lib/subscriptionUtils.js';
 
 const AudiobookPage = () => {
   // Mock data
@@ -25,6 +26,15 @@ const AudiobookPage = () => {
   const infiniteBooks = Array(15).fill(sampleBooks.slice(0, 10)).flat();
 
   const [plans, setPlans] = useState([]);
+
+  const handlePlanSelect = async (plan) => {
+    try {
+      await purchasePlan(api, plan);
+      toast({ title: `تم الاشتراك في ${plan.name}` });
+    } catch (e) {
+      toast({ title: 'تعذر إتمام الاشتراك. حاول مجدداً.', variant: 'destructive' });
+    }
+  };
 
   useEffect(() => {
     (async () => {
@@ -158,7 +168,10 @@ const AudiobookPage = () => {
                 </div>
               </div>
               <p className="text-sm text-gray-700 mb-6 text-center" dangerouslySetInnerHTML={{ __html: plan.description }} />
-              <Button className="w-full bg-[#E4E6FF] hover:bg-[#d6d8f2] text-[#315dfb] border border-[#E4E6FF]" onClick={() => toast({ title: `تم اختيار ${plan.name}` })}>
+              <Button
+                className="w-full bg-[#E4E6FF] hover:bg-[#d6d8f2] text-[#315dfb] border border-[#E4E6FF]"
+                onClick={() => handlePlanSelect(plan)}
+              >
                 اختر باقتك
               </Button>
             </motion.div>

--- a/src/pages/EbookPage.jsx
+++ b/src/pages/EbookPage.jsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button.jsx';
 import { toast } from '@/components/ui/use-toast.js';
 import api from '@/lib/api.js';
+import { purchasePlan } from '@/lib/subscriptionUtils.js';
 import { BookCard } from '@/components/FlashSaleSection.jsx';
 import { Check, Award, Star } from 'lucide-react';
 
@@ -26,6 +27,15 @@ const EbookPage = ({ books, authors, handleAddToCart, handleToggleWishlist, wish
   );
 
   const [plans, setPlans] = useState([]);
+
+  const handlePlanSelect = async (plan) => {
+    try {
+      await purchasePlan(api, plan);
+      toast({ title: `تم الاشتراك في ${plan.name}` });
+    } catch (e) {
+      toast({ title: 'تعذر إتمام الاشتراك. حاول مجدداً.', variant: 'destructive' });
+    }
+  };
 
   useEffect(() => {
     (async () => {
@@ -99,7 +109,10 @@ const EbookPage = ({ books, authors, handleAddToCart, handleToggleWishlist, wish
                 </div>
               </div>
               <p className="text-sm text-gray-700 mb-6 text-center" dangerouslySetInnerHTML={{ __html: plan.description }} />
-              <Button className="w-full bg-[#E4E6FF] hover:bg-[#d6d8f2] text-[#315dfb] border border-[#E4E6FF]" onClick={() => toast({ title: `تم اختيار ${plan.name}` })}>
+              <Button
+                className="w-full bg-[#E4E6FF] hover:bg-[#d6d8f2] text-[#315dfb] border border-[#E4E6FF]"
+                onClick={() => handlePlanSelect(plan)}
+              >
                 اختر باقتك
               </Button>
             </motion.div>


### PR DESCRIPTION
## Summary
- add helper to create a subscription and related payment
- connect Subscription dialog to the new purchase logic
- allow plan purchase from ebook and audiobook pages

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886010bb374832a97e24a9b6a24bd2d