### PR TITLE
Remove payment settings from site config

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -2975,25 +2975,6 @@ const DashboardSettings = ({ siteSettings, setSiteSettings, currencies = [] }) =
             <Label htmlFor="languages">اللغات المتاحة (افصل بينها بفاصلة)</Label>
             <Input id="languages" name="languages" value={formData.languages} onChange={handleChange} />
           </div>
-          <div className="md:col-span-2 border-t pt-4">
-            <h4 className="font-semibold mb-2">إعدادات الدفع</h4>
-          </div>
-          <div>
-            <Label htmlFor="stripePublicKey">Stripe Public Key</Label>
-            <Input id="stripePublicKey" name="stripePublicKey" value={formData.stripePublicKey} onChange={handleChange} />
-          </div>
-          <div>
-            <Label htmlFor="stripeSecretKey">Stripe Secret Key</Label>
-            <Input id="stripeSecretKey" name="stripeSecretKey" value={formData.stripeSecretKey} onChange={handleChange} />
-          </div>
-          <div>
-            <Label htmlFor="paypalClientId">PayPal Client ID</Label>
-            <Input id="paypalClientId" name="paypalClientId" value={formData.paypalClientId} onChange={handleChange} />
-          </div>
-          <div>
-            <Label htmlFor="paypalSecret">PayPal Secret</Label>
-            <Input id="paypalSecret" name="paypalSecret" value={formData.paypalSecret} onChange={handleChange} />
-          </div>
         </div>
         <div className="flex justify-end">
           <Button type="submit" className="bg-gradient-to-r from-blue-600 to-purple-600 text-white">

--- a/src/data/siteData.js
+++ b/src/data/siteData.js
@@ -333,11 +333,7 @@ export const siteSettings = {
   facebook: '',
   twitter: '',
   instagram: '',
-  themeColor: '#1D4ED8',
-  stripePublicKey: import.meta.env.VITE_STRIPE_PUBLIC_KEY || '',
-  stripeSecretKey: '',
-  paypalClientId: import.meta.env.VITE_PAYPAL_CLIENT_ID || '',
-  paypalSecret: ''
+  themeColor: '#1D4ED8'
 };
 
 export const paymentMethods = [


### PR DESCRIPTION
## Summary
- remove payment gateways section in Dashboard settings
- remove payment settings fields from default site settings

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688608e0f71c832aa43f32ba173e2011