### PR TITLE
feat: protect admin routes with Firebase roles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,6 +54,7 @@ import ScrollToTop from '@/components/ScrollToTop.jsx';
 import ChatWidget from '@/components/ChatWidget.jsx';
 import SplashScreen from '@/components/SplashScreen.jsx';
 import MobileBottomNav from '@/components/MobileBottomNav.jsx';
+import RequireAdmin from '@/components/RequireAdmin.jsx';
 
 import { sellers as initialSellers, branches as initialBranches, users as initialUsers, footerLinks, siteSettings as initialSiteSettings, paymentMethods as initialPaymentMethods } from '@/data/siteData.js';
 import api from '@/lib/api.js';
@@ -142,12 +143,6 @@ const App = () => {
           }
         }
         
-        // فحص إضافي من localStorage للتحقق من حالة المدير
-        const adminLoggedIn = localStorage.getItem('adminLoggedIn');
-        const userRole = localStorage.getItem('userRole');
-        if (adminLoggedIn === 'true' && (userRole === 'admin' || userRole === 'manager')) {
-          setIsAdminLoggedIn(true);
-        }
       } catch (error) {
         const errorObject = errorHandler.handleError(error, 'auth:status-check');
         console.error('Auth status check failed:', errorObject);
@@ -179,14 +174,8 @@ const App = () => {
           
           if (userData && (userData.role === 'admin' || userData.role === 'manager')) {
             setIsAdminLoggedIn(true);
-            // تحديث localStorage
-            localStorage.setItem('adminLoggedIn', 'true');
-            localStorage.setItem('currentUserId', user.uid);
-            localStorage.setItem('userRole', userData.role);
           } else {
             setIsAdminLoggedIn(false);
-            localStorage.removeItem('adminLoggedIn');
-            localStorage.removeItem('userRole');
           }
         } catch (error) {
           console.error('Error checking user role:', error);
@@ -196,8 +185,6 @@ const App = () => {
         setCurrentUser(null);
         setIsCustomerLoggedIn(false);
         setIsAdminLoggedIn(false);
-        localStorage.removeItem('adminLoggedIn');
-        localStorage.removeItem('userRole');
       }
     });
 
@@ -698,7 +685,7 @@ const App = () => {
               <Route
                 path="/admin"
                 element={
-                  isAdminLoggedIn ? (
+                  <RequireAdmin>
                     <Dashboard
                       dashboardStats={dashboardStatsState}
                       books={books}
@@ -741,31 +728,27 @@ const App = () => {
                       features={features}
                       setFeatures={setFeatures}
                     />
-                  ) : (
-                    <AdminLoginPage 
-                      onLogin={() => {
-                        setIsAdminLoggedIn(true);
-                        setIsCustomerLoggedIn(true);
-                      }} 
-                      setCurrentUser={setCurrentUser}
-                    />
-                  )
+                  </RequireAdmin>
                 }
               />
               <Route
                 path="/admin/orders/:id"
                 element={
-                  isAdminLoggedIn ? (
+                  <RequireAdmin>
                     <DashboardOrderDetailsPage />
-                  ) : (
-                    <AdminLoginPage 
-                      onLogin={() => {
-                        setIsAdminLoggedIn(true);
-                        setIsCustomerLoggedIn(true);
-                      }} 
-                      setCurrentUser={setCurrentUser}
-                    />
-                  )
+                  </RequireAdmin>
+                }
+              />
+              <Route
+                path="/admin/login"
+                element={
+                  <AdminLoginPage
+                    onLogin={() => {
+                      setIsAdminLoggedIn(true);
+                      setIsCustomerLoggedIn(true);
+                    }}
+                    setCurrentUser={setCurrentUser}
+                  />
                 }
               />
               <Route

--- a/src/components/RequireAdmin.jsx
+++ b/src/components/RequireAdmin.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { auth, db } from '@/lib/firebase.js';
+import { doc, getDoc } from 'firebase/firestore';
+import { onAuthStateChanged } from 'firebase/auth';
+
+const RequireAdmin = ({ children }) => {
+  const [loading, setLoading] = React.useState(true);
+  const [isAdmin, setIsAdmin] = React.useState(false);
+  const location = useLocation();
+
+  React.useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (user) {
+        try {
+          const userDoc = await getDoc(doc(db, 'users', user.uid));
+          const data = userDoc.data();
+          if (data && (data.role === 'admin' || data.role === 'manager')) {
+            setIsAdmin(true);
+          } else {
+            setIsAdmin(false);
+          }
+        } catch (err) {
+          console.error('Error checking admin role:', err);
+          setIsAdmin(false);
+        }
+      } else {
+        setIsAdmin(false);
+      }
+      setLoading(false);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  if (loading) {
+    return null;
+  }
+
+  if (!isAdmin) {
+    return <Navigate to="/admin/login" state={{ from: location }} replace />;
+  }
+
+  return children;
+};
+
+export default RequireAdmin;


### PR DESCRIPTION
## Summary
- replace admin login localStorage usage with Firebase Auth and Firestore roles
- add RequireAdmin component to gate admin routes by role
- wrap admin pages with RequireAdmin and add dedicated admin login route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found; dependencies unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6860d1b6c832abf12fd9fa51bb74f