### PR TITLE
feat: validate data with shared schemas

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,7 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const cors = require('cors')({ origin: true });
+const { Schemas, validateData } = require('../src/lib/models/schemas.js');
 
 // Initialize Firebase Admin
 admin.initializeApp();
@@ -197,6 +198,37 @@ exports.updateStock = functions.https.onCall(async (data, context) => {
     console.error('Stock Update Error:', error);
     throw new functions.https.HttpsError('internal', error.message);
   }
+});
+
+// ===== SCHEMA VALIDATION =====
+exports.validateSchema = functions.firestore.document('{collectionId}/{docId}').onCreate(async (snap, context) => {
+  const { collectionId } = context.params;
+  const data = snap.data();
+  let schema = null;
+
+  switch (collectionId) {
+    case 'orders':
+      schema = Schemas.Order;
+      break;
+    case 'order_items':
+      schema = Schemas.OrderItem;
+      break;
+    case 'payments':
+      schema = Schemas.Payment;
+      break;
+    case 'shipping':
+      schema = Schemas.Shipping;
+      break;
+    default:
+      return null;
+  }
+
+  const errors = validateData(data, schema);
+  if (errors.length > 0) {
+    console.error(`Invalid ${collectionId} document:`, errors);
+    await snap.ref.delete();
+  }
+  return null;
 });
 
 // ===== ANALYTICS =====

--- a/src/lib/models/schemas.js
+++ b/src/lib/models/schemas.js
@@ -1,0 +1,96 @@
+export const OrderItemSchema = {
+  type: 'object',
+  required: ['productId', 'quantity', 'unitPrice'],
+  properties: {
+    productId: { type: 'string' },
+    productType: { type: 'string' },
+    title: { type: 'string' },
+    quantity: { type: 'number' },
+    unitPrice: { type: 'number' },
+    weight: { type: 'number' }
+  }
+};
+
+export const ShippingSchema = {
+  type: 'object',
+  required: ['orderId', 'shippingAddress'],
+  properties: {
+    orderId: { type: 'string' },
+    shippingAddress: { type: 'object' },
+    shippingMethod: { type: 'string' },
+    shippingCost: { type: 'number' },
+    currency: { type: 'string' }
+  }
+};
+
+export const PaymentSchema = {
+  type: 'object',
+  required: ['orderId', 'amount', 'paymentMethod'],
+  properties: {
+    orderId: { type: 'string' },
+    customerId: { type: 'string' },
+    amount: { type: 'number' },
+    currency: { type: 'string' },
+    paymentMethod: { type: 'string' }
+  }
+};
+
+export const OrderSchema = {
+  type: 'object',
+  required: ['customerId', 'items', 'totalAmount', 'currency'],
+  properties: {
+    customerId: { type: 'string' },
+    customerEmail: { type: 'string' },
+    customerName: { type: 'string' },
+    items: { type: 'array', items: OrderItemSchema },
+    subtotal: { type: 'number' },
+    shippingCost: { type: 'number' },
+    taxAmount: { type: 'number' },
+    totalAmount: { type: 'number' },
+    currency: { type: 'string' },
+    shippingAddress: { type: 'object' },
+    shippingMethod: { type: 'string' }
+  }
+};
+
+export function validateData(data, schema, path = '') {
+  const errors = [];
+  if (schema.type === 'object') {
+    const obj = data || {};
+    const required = schema.required || [];
+    for (const field of required) {
+      if (obj[field] === undefined || obj[field] === null) {
+        errors.push(`${path}${field} is required`);
+      }
+    }
+    for (const [key, propSchema] of Object.entries(schema.properties || {})) {
+      if (obj[key] !== undefined && obj[key] !== null) {
+        errors.push(...validateData(obj[key], propSchema, `${path}${key}.`));
+      }
+    }
+  } else if (schema.type === 'array') {
+    if (!Array.isArray(data)) {
+      errors.push(`${path.replace(/\.$/, '')} must be an array`);
+    } else {
+      data.forEach((item, index) => {
+        errors.push(...validateData(item, schema.items, `${path}${index}.`));
+      });
+    }
+  } else {
+    if (schema.type && typeof data !== schema.type) {
+      errors.push(`${path.replace(/\.$/, '')} must be of type ${schema.type}`);
+    }
+  }
+  return errors;
+}
+
+export const Schemas = {
+  Order: OrderSchema,
+  OrderItem: OrderItemSchema,
+  Payment: PaymentSchema,
+  Shipping: ShippingSchema
+};
+
+if (typeof module !== 'undefined') {
+  module.exports = { Schemas, validateData };
+}

--- a/src/lib/services/CheckoutService.js
+++ b/src/lib/services/CheckoutService.js
@@ -6,6 +6,7 @@ import { Order } from '../models/Order.js';
 import { OrderItem } from '../models/OrderItem.js';
 import { Payment } from '../models/Payment.js';
 import { Shipping } from '../models/Shipping.js';
+import { Schemas, validateData } from '../models/schemas.js';
 import { errorHandler } from '../errorHandler.js';
 import OrderService from './OrderService.js';
 import PaymentService from './PaymentService.js';
@@ -144,6 +145,17 @@ export class CheckoutService {
 
       console.log('CheckoutService - Creating order with data:', orderData);
 
+      // التحقق من صحة بيانات الطلب قبل الحفظ
+      const orderValidationErrors = validateData(orderData, Schemas.Order);
+      if (orderValidationErrors.length > 0) {
+        throw errorHandler.createError(
+          'VALIDATION',
+          'validation/order-invalid',
+          `خطأ في بيانات الطلب: ${orderValidationErrors.join(', ')}`,
+          'checkout-order-creation'
+        );
+      }
+
       const order = await this.orderService.createOrder(orderData);
       
       // تسجيل مفصل لبيانات الطلب المُنشأ
@@ -170,7 +182,7 @@ export class CheckoutService {
       // إنشاء معلومات الشحن (إذا كان هناك منتجات مادية)
       let shipping = null;
       if (this.hasPhysicalItems(items)) {
-        shipping = await this.shippingService.createShipping({
+        const shippingData = {
           orderId: order.order.id,
           customerId,
           shippingMethod,
@@ -178,11 +190,21 @@ export class CheckoutService {
           packageWeight: costCalculation.totalWeight,
           packageDimensions: costCalculation.packageDimensions,
           packageCount: items.length
-        });
+        };
+        const shippingErrors = validateData(shippingData, Schemas.Shipping);
+        if (shippingErrors.length > 0) {
+          throw errorHandler.createError(
+            'VALIDATION',
+            'validation/shipping-invalid',
+            `خطأ في بيانات الشحن: ${shippingErrors.join(', ')}`,
+            'checkout-shipping-creation'
+          );
+        }
+        shipping = await this.shippingService.createShipping(shippingData);
       }
 
       // إنشاء عملية الدفع
-      const payment = await this.paymentService.createPayment({
+      const paymentData = {
         orderId: order.order.id,
         customerId,
         amount: order.order.total,
@@ -192,7 +214,17 @@ export class CheckoutService {
         customerEmail: customerInfo.email,
         customerPhone: customerInfo.phone,
         billingAddress: shippingAddress
-      });
+      };
+      const paymentErrors = validateData(paymentData, Schemas.Payment);
+      if (paymentErrors.length > 0) {
+        throw errorHandler.createError(
+          'VALIDATION',
+          'validation/payment-invalid',
+          `خطأ في بيانات الدفع: ${paymentErrors.join(', ')}`,
+          'checkout-payment-creation'
+        );
+      }
+      const payment = await this.paymentService.createPayment(paymentData);
 
       // معالجة الدفع
       let paymentResult;

--- a/src/lib/services/OrderService.js
+++ b/src/lib/services/OrderService.js
@@ -6,6 +6,7 @@ import { Order } from '../models/Order.js';
 import { OrderItem } from '../models/OrderItem.js';
 import { Payment } from '../models/Payment.js';
 import { Shipping } from '../models/Shipping.js';
+import { Schemas, validateData } from '../models/schemas.js';
 import { errorHandler } from '../errorHandler.js';
 import firebaseApi from '../firebaseApi.js';
 
@@ -22,8 +23,8 @@ export class OrderService {
       // إنشاء نموذج الطلب
       const order = new Order(orderData);
       
-      // التحقق من صحة البيانات
-      const validationErrors = order.validate();
+      // التحقق من صحة البيانات باستخدام المخطط الموحد
+      const validationErrors = validateData(orderData, Schemas.Order);
       if (validationErrors.length > 0) {
         throw errorHandler.createError(
           'VALIDATION',

--- a/src/lib/services/PaymentService.js
+++ b/src/lib/services/PaymentService.js
@@ -3,6 +3,7 @@
  */
 
 import { Payment, PAYMENT_STATUSES, PAYMENT_METHODS } from '../models/Payment.js';
+import { Schemas, validateData } from '../models/schemas.js';
 import { errorHandler } from '../errorHandler.js';
 import firebaseApi from '../firebaseApi.js';
 
@@ -18,9 +19,9 @@ export class PaymentService {
     try {
       // إنشاء نموذج الدفع
       const payment = new Payment(paymentData);
-      
-      // التحقق من صحة البيانات
-      const validationErrors = payment.validate();
+
+      // التحقق من صحة البيانات باستخدام المخطط الموحد
+      const validationErrors = validateData(paymentData, Schemas.Payment);
       if (validationErrors.length > 0) {
         throw errorHandler.createError(
           'VALIDATION',


### PR DESCRIPTION
## Summary
- add unified Order, Payment, Shipping and OrderItem schemas with reusable validator
- apply schema validation in order, payment and checkout services
- add Cloud Function to reject documents that fail schema validation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix functions run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c68962cdfc832ab376c58f0c772287