### PR TITLE
feat: add order lifecycle service and admin notifications

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,7 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const cors = require('cors')({ origin: true });
+const orderLifecycle = require('./orderLifecycleService');
 
 // Initialize Firebase Admin
 admin.initializeApp();
@@ -321,3 +322,8 @@ exports.validateUserAccess = functions.https.onCall(async (data, context) => {
     throw new functions.https.HttpsError('internal', error.message);
   }
 });
+
+// ===== ORDER LIFECYCLE SERVICE =====
+exports.handlePaymentWebhook = orderLifecycle.handlePaymentWebhook;
+exports.handleShipmentWebhook = orderLifecycle.handleShipmentWebhook;
+exports.checkPendingOrders = orderLifecycle.checkPendingOrders;

--- a/functions/orderLifecycleService.js
+++ b/functions/orderLifecycleService.js
@@ -1,0 +1,130 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+// reuse initialized admin app from index.js or initialize if not already
+try {
+  admin.app();
+} catch (e) {
+  admin.initializeApp();
+}
+
+const db = admin.firestore();
+
+// Handle payment provider webhooks
+const handlePaymentWebhook = functions.https.onRequest(async (req, res) => {
+  try {
+    const { orderId, status } = req.body;
+    if (!orderId || !status) {
+      res.status(400).send('Missing orderId or status');
+      return;
+    }
+
+    const orderRef = db.collection('orders').doc(orderId);
+    await orderRef.update({
+      status,
+      stageHistory: admin.firestore.FieldValue.arrayUnion({
+        stage: `payment_${status}`,
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      }),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    res.status(200).send('ok');
+  } catch (error) {
+    console.error('Payment webhook error', error);
+    await db.collection('notifications').add({
+      type: 'payment',
+      message: error.message,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    res.status(500).send('error');
+  }
+});
+
+// Handle shipping provider webhooks
+const handleShipmentWebhook = functions.https.onRequest(async (req, res) => {
+  try {
+    const { orderId, status } = req.body;
+    if (!orderId || !status) {
+      res.status(400).send('Missing orderId or status');
+      return;
+    }
+
+    const orderRef = db.collection('orders').doc(orderId);
+    await orderRef.update({
+      shippingStatus: status,
+      stageHistory: admin.firestore.FieldValue.arrayUnion({
+        stage: `shipping_${status}`,
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      }),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    if (status === 'delivered') {
+      await orderRef.update({
+        status: 'completed',
+        stageHistory: admin.firestore.FieldValue.arrayUnion({
+          stage: 'completed',
+          timestamp: admin.firestore.FieldValue.serverTimestamp(),
+        }),
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+    }
+
+    res.status(200).send('ok');
+  } catch (error) {
+    console.error('Shipment webhook error', error);
+    await db.collection('notifications').add({
+      type: 'shipment',
+      message: error.message,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    res.status(500).send('error');
+  }
+});
+
+// Scheduled function to clean up pending orders
+const checkPendingOrders = functions.pubsub
+  .schedule('every 24 hours')
+  .timeZone('Asia/Riyadh')
+  .onRun(async () => {
+    const expirationTime = Date.now() - 1000 * 60 * 60 * 24; // 24 hours
+    const snapshot = await db
+      .collection('orders')
+      .where('status', '==', 'pending')
+      .get();
+
+    const batch = db.batch();
+    snapshot.forEach((doc) => {
+      const data = doc.data();
+      const updatedAt = data.updatedAt ? data.updatedAt.toDate().getTime() : 0;
+      if (data.paymentStatus === 'succeeded' && data.shippingStatus === 'delivered') {
+        batch.update(doc.ref, {
+          status: 'completed',
+          stageHistory: admin.firestore.FieldValue.arrayUnion({
+            stage: 'completed',
+            timestamp: admin.firestore.FieldValue.serverTimestamp(),
+          }),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+      } else if (updatedAt < expirationTime) {
+        batch.update(doc.ref, {
+          status: 'expired',
+          stageHistory: admin.firestore.FieldValue.arrayUnion({
+            stage: 'expired',
+            timestamp: admin.firestore.FieldValue.serverTimestamp(),
+          }),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+      }
+    });
+
+    await batch.commit();
+    return null;
+  });
+
+module.exports = {
+  handlePaymentWebhook,
+  handleShipmentWebhook,
+  checkPendingOrders,
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -92,6 +92,7 @@ const App = () => {
   const [orders, setOrders] = useState(() => JSON.parse(localStorage.getItem('orders') || '[]'));
   const [payments, setPayments] = useState(() => JSON.parse(localStorage.getItem('payments') || '[]'));
   const [messages, setMessages] = useState([]);
+  const [notifications, setNotifications] = useState(() => JSON.parse(localStorage.getItem('notifications') || '[]'));
   const [paymentMethods, setPaymentMethods] = useState(() => {
     const stored = localStorage.getItem('paymentMethods');
     return stored ? JSON.parse(stored) : initialPaymentMethods;
@@ -507,6 +508,10 @@ const App = () => {
     localStorage.setItem('messages', JSON.stringify(messages));
   }, [messages]);
 
+  useEffect(() => {
+    localStorage.setItem('notifications', JSON.stringify(notifications));
+  }, [notifications]);
+
   // تحديث إحصائيات لوحة التحكم
   useEffect(() => {
     const sales = payments.reduce((sum, p) => sum + (Number(p.amount) || 0), 0);
@@ -732,6 +737,8 @@ const App = () => {
                       setUsers={setUsers}
                       messages={messages}
                       setMessages={setMessages}
+                      notifications={notifications}
+                      setNotifications={setNotifications}
                       siteSettings={siteSettingsState}
                       setSiteSettings={setSiteSettingsState}
                       sliders={heroSlidesState}

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -5187,7 +5187,7 @@ const PlaceholderSection = ({ sectionName, handleFeatureClick }) => (
 );
 
 
-const Dashboard = ({ dashboardStats, books, authors, sellers, branches, categories, orders, payments, paymentMethods, currencies, languages, plans, subscriptions, users, messages, dashboardSection, setDashboardSection, handleFeatureClick, setBooks, setAuthors, setSellers, setBranches, setCategories, setOrders, setPayments, setPaymentMethods, setCurrencies, setLanguages, setPlans, setSubscriptions, setUsers, setMessages, siteSettings, setSiteSettings, sliders, setSliders, banners, setBanners, features, setFeatures }) => {
+const Dashboard = ({ dashboardStats, books, authors, sellers, branches, categories, orders, payments, paymentMethods, currencies, languages, plans, subscriptions, users, messages, notifications, dashboardSection, setDashboardSection, handleFeatureClick, setBooks, setAuthors, setSellers, setBranches, setCategories, setOrders, setPayments, setPaymentMethods, setCurrencies, setLanguages, setPlans, setSubscriptions, setUsers, setMessages, setNotifications, siteSettings, setSiteSettings, sliders, setSliders, banners, setBanners, features, setFeatures }) => {
   const { t } = useTranslation();
   const { formatPrice } = useCurrency();
   const navigate = useNavigate();
@@ -5565,6 +5565,20 @@ const Dashboard = ({ dashboardStats, books, authors, sellers, branches, categori
     }
   };
 
+  const fetchNotifications = async () => {
+    try {
+      const notes = await firebaseApi.getCollection('notifications');
+      setNotifications(notes);
+    } catch (error) {
+      console.error('Error fetching notifications:', error);
+      toast({
+        title: "خطأ",
+        description: "فشل جلب الإشعارات",
+        variant: "destructive",
+      });
+    }
+  };
+
   // دوال الحذف
   const handleDeleteBlog = async (id) => {
     if (confirmDelete()) {
@@ -5721,6 +5735,8 @@ const Dashboard = ({ dashboardStats, books, authors, sellers, branches, categori
       fetchDistributors();
     } else if (dashboardSection === 'team') {
       fetchTeamMembers();
+    } else if (dashboardSection === 'notifications') {
+      fetchNotifications();
     } else if (dashboardSection === 'design-requests') {
       fetchDesignRequests();
     } else if (dashboardSection === 'publishing-requests') {
@@ -5944,6 +5960,27 @@ const Dashboard = ({ dashboardStats, books, authors, sellers, branches, categori
         )}
         {dashboardSection === 'messages' && (
           <DashboardMessages messages={messages} />
+        )}
+        {dashboardSection === 'notifications' && (
+          <div className="bg-white rounded-lg shadow-lg p-6">
+            <h2 className="text-2xl font-bold text-gray-800 mb-6">الإشعارات</h2>
+            {notifications.length === 0 ? (
+              <p className="text-gray-500">لا توجد إشعارات</p>
+            ) : (
+              <div className="space-y-4">
+                {notifications.map((note, idx) => (
+                  <div key={idx} className="border-b pb-2">
+                    <p className="text-sm text-gray-700">{note.message || note.title}</p>
+                    {note.createdAt && (
+                      <span className="text-xs text-gray-500">
+                        {new Date(note.createdAt).toLocaleString('ar-SA')}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         )}
         {dashboardSection === 'features' && <DashboardFeatures features={features} setFeatures={setFeatures} />}
         {dashboardSection === 'sliders' && <DashboardSliders sliders={sliders} setSliders={setSliders} />}


### PR DESCRIPTION
## Summary
- add OrderLifecycleService to handle payment/shipping webhooks and scheduled pending-order checks
- expose lifecycle handlers from cloud functions index
- surface admin notifications in dashboard with persisted state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*
- `npm --prefix functions test` *(fails: Missing script "test")*
- `npm --prefix functions run lint` *(fails: ESLint couldn't find a configuration file)*


------
https://chatgpt.com/codex/tasks/task_e_68c68baa1a6c832aab3218b7010e7ae6