### PR TITLE
refactor: introduce app contexts and lazy routes

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -31,7 +31,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { useCurrency } from '@/lib/currencyContext.jsx';
 import { useLanguage, useTranslation } from '@/lib/languageContext.jsx';
 
-const Header = ({ handleFeatureClick, cartItemCount, isCustomerLoggedIn, books = [], categories = [], siteSettings = {} }) => {
+const Header = ({ handleFeatureClick, books = [], categories = [], siteSettings = {} }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [suggestions, setSuggestions] = useState([]);
   const [recentSearches, setRecentSearches] = useState(() => {
@@ -46,6 +46,8 @@ const Header = ({ handleFeatureClick, cartItemCount, isCustomerLoggedIn, books =
   const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false);
   const { currency, setCurrency, currencies } = useCurrency();
   const { language, setLanguage, languages } = useLanguage();
+  const { cart } = useCart();
+  const { isCustomer: isCustomerLoggedIn } = useAuth();
   const t = useTranslation();
   const navigate = useNavigate();
 
@@ -416,13 +418,13 @@ const Header = ({ handleFeatureClick, cartItemCount, isCustomerLoggedIn, books =
               <Button asChild variant="ghost" size="icon" className="relative text-white hover:text-gray-200 w-10 h-10 transition-all duration-200">
               <Link to="/cart">
                 <ShoppingCart className="w-5 h-5" />
-                {cartItemCount > 0 && (
-                    <motion.span 
+                {cart.reduce((sum, item) => sum + item.quantity, 0) > 0 && (
+                    <motion.span
                       initial={{ scale: 0 }}
                       animate={{ scale: 1 }}
                       className="absolute -top-0.5 -right-0.5 bg-red-500 text-white text-[10px] font-semibold rounded-full w-3.5 h-3.5 flex items-center justify-center"
                     >
-                    {cartItemCount}
+                    {cart.reduce((sum, item) => sum + item.quantity, 0)}
                     </motion.span>
                 )}
               </Link>

--- a/src/components/MobileBottomNav.jsx
+++ b/src/components/MobileBottomNav.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { 
-  Home, 
-  ShoppingBag, 
-  ShoppingCart, 
-  BookOpen, 
-  User 
+import {
+  Home,
+  ShoppingBag,
+  ShoppingCart,
+  BookOpen,
+  User
 } from 'lucide-react';
+import { useCart } from '@/lib/cartContext.jsx';
 
-const MobileBottomNav = ({ cartItemCount = 0 }) => {
+const MobileBottomNav = () => {
   const location = useLocation();
+  const { cart } = useCart();
+  const cartItemCount = cart.reduce((sum, item) => sum + item.quantity, 0);
 
   const navItems = [
     {

--- a/src/lib/authContext.jsx
+++ b/src/lib/authContext.jsx
@@ -1,0 +1,83 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { jwtAuthManager, firebaseAuth } from '@/lib/jwtAuth.js';
+import { errorHandler } from '@/lib/errorHandler.js';
+
+const AuthContext = createContext(null);
+
+export const AuthProvider = ({ children }) => {
+  const [currentUser, setCurrentUser] = useState(null);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [isCustomer, setIsCustomer] = useState(false);
+
+  useEffect(() => {
+    const checkAuthStatus = () => {
+      try {
+        const user = jwtAuthManager.getCurrentUser();
+        if (user) {
+          setCurrentUser(user);
+          setIsCustomer(true);
+          if (user.isAdmin || user.role === 'admin') {
+            setIsAdmin(true);
+          }
+        }
+      } catch (error) {
+        const errorObject = errorHandler.handleError(error, 'auth:status-check');
+        console.error('Auth status check failed:', errorObject);
+        jwtAuthManager.clearTokens();
+        setIsCustomer(false);
+        setIsAdmin(false);
+        setCurrentUser(null);
+      }
+    };
+    checkAuthStatus();
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = firebaseAuth.onAuthStateChange(async ({ user, isAuthenticated }) => {
+      if (isAuthenticated && user) {
+        setCurrentUser(user);
+        setIsCustomer(true);
+        try {
+          const { doc, getDoc } = await import('firebase/firestore');
+          const { db } = await import('@/lib/firebase.js');
+          const userDoc = await getDoc(doc(db, 'users', user.uid));
+          const userData = userDoc.data();
+          if (userData && (userData.role === 'admin' || userData.role === 'manager')) {
+            setIsAdmin(true);
+          } else {
+            setIsAdmin(false);
+          }
+        } catch (err) {
+          console.error('Error checking user role:', err);
+          setIsAdmin(false);
+        }
+      } else {
+        setCurrentUser(null);
+        setIsCustomer(false);
+        setIsAdmin(false);
+      }
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const login = (user, options = { isAdmin: false }) => {
+    setCurrentUser(user);
+    setIsCustomer(true);
+    setIsAdmin(!!options.isAdmin);
+  };
+
+  const logout = () => {
+    jwtAuthManager.clearTokens();
+    setCurrentUser(null);
+    setIsAdmin(false);
+    setIsCustomer(false);
+  };
+
+  return (
+    <AuthContext.Provider value={{ currentUser, isAdmin, isCustomer, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/lib/cartContext.jsx
+++ b/src/lib/cartContext.jsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const CartContext = createContext(null);
+
+export const CartProvider = ({ children }) => {
+  const [cart, setCart] = useState([]);
+
+  const addToCart = (item) => {
+    setCart(prev => [...prev, item]);
+  };
+
+  const removeFromCart = (id) => {
+    setCart(prev => prev.filter(item => item.id !== id));
+  };
+
+  const updateQuantity = (id, quantity) => {
+    setCart(prev => prev.map(item => item.id === id ? { ...item, quantity } : item));
+  };
+
+  const clearCart = () => setCart([]);
+
+  return (
+    <CartContext.Provider value={{ cart, setCart, addToCart, removeFromCart, updateQuantity, clearCart }}>
+      {children}
+    </CartContext.Provider>
+  );
+};
+
+export const useCart = () => useContext(CartContext);

--- a/src/lib/favoritesContext.jsx
+++ b/src/lib/favoritesContext.jsx
@@ -1,0 +1,22 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const FavoritesContext = createContext(null);
+
+export const FavoritesProvider = ({ children }) => {
+  const [favorites, setFavorites] = useState([]);
+
+  const toggleFavorite = (book) => {
+    setFavorites(prev => {
+      const exists = prev.find(item => item.id === book.id);
+      return exists ? prev.filter(item => item.id !== book.id) : [...prev, book];
+    });
+  };
+
+  return (
+    <FavoritesContext.Provider value={{ favorites, toggleFavorite }}>
+      {children}
+    </FavoritesContext.Provider>
+  );
+};
+
+export const useFavorites = () => useContext(FavoritesContext);

--- a/src/lib/settingsContext.jsx
+++ b/src/lib/settingsContext.jsx
@@ -1,0 +1,15 @@
+import React, { createContext, useContext, useState } from 'react';
+import { siteSettings as defaultSettings } from '@/data/siteData.js';
+
+const SettingsContext = createContext(null);
+
+export const SettingsProvider = ({ children }) => {
+  const [settings, setSettings] = useState(defaultSettings);
+  return (
+    <SettingsContext.Provider value={{ settings, setSettings }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => useContext(SettingsContext);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,11 +6,23 @@ import './index.css';
 import './lib/i18n';
 import { I18nextProvider } from 'react-i18next';
 import i18n from './lib/i18n';
+import { AuthProvider } from '@/lib/authContext.jsx';
+import { CartProvider } from '@/lib/cartContext.jsx';
+import { FavoritesProvider } from '@/lib/favoritesContext.jsx';
+import { SettingsProvider } from '@/lib/settingsContext.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <I18nextProvider i18n={i18n}>
-      <App />
+      <AuthProvider>
+        <SettingsProvider>
+          <CartProvider>
+            <FavoritesProvider>
+              <App />
+            </FavoritesProvider>
+          </CartProvider>
+        </SettingsProvider>
+      </AuthProvider>
     </I18nextProvider>
   </React.StrictMode>
 );

--- a/src/routes/AdminRoutes.jsx
+++ b/src/routes/AdminRoutes.jsx
@@ -1,0 +1,40 @@
+import React, { Suspense } from 'react';
+import { Routes, Route } from 'react-router-dom';
+import RequireAdmin from '@/components/RequireAdmin.jsx';
+import { useAuth } from '@/lib/authContext.jsx';
+
+const Dashboard = React.lazy(() => import('@/components/Dashboard.jsx'));
+const DashboardOrderDetailsPage = React.lazy(() => import('@/pages/DashboardOrderDetailsPage.jsx'));
+const AdminLoginPage = React.lazy(() => import('@/pages/AdminLoginPage.jsx'));
+
+const AdminRoutes = ({ dashboardProps = {} }) => {
+  const { login } = useAuth();
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Routes>
+        <Route
+          path=""
+          element={
+            <RequireAdmin>
+              <Dashboard {...dashboardProps} />
+            </RequireAdmin>
+          }
+        />
+        <Route
+          path="orders/:id"
+          element={
+            <RequireAdmin>
+              <DashboardOrderDetailsPage />
+            </RequireAdmin>
+          }
+        />
+        <Route
+          path="login"
+          element={<AdminLoginPage onLogin={(user) => login(user, { isAdmin: true })} />}
+        />
+      </Routes>
+    </Suspense>
+  );
+};
+
+export default AdminRoutes;


### PR DESCRIPTION
## Summary
- add Auth, Cart, Favorites, and Settings context providers
- remove localStorage persistence for orders and users in favor of Firestore state
- split admin routing into lazy-loaded module

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden fetching @testing-library/react)*

------
https://chatgpt.com/codex/tasks/task_e_68c6982b0ea8832a9fd4fd9285a6fe8c