### PR TITLE
Remove duplicate Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -169,12 +169,6 @@ service cloud.firestore {
       allow update, delete: if isManager();
     }
 
-    // Settings collection
-    match /settings/{settingId} {
-      allow read: if true;
-      allow write: if isManager();
-    }
-
     // Messages collection
     match /messages/{messageId} {
       allow read, write: if isOwner(resource.data.userId) || isManagerOrDevelopment();
@@ -301,12 +295,6 @@ service cloud.firestore {
 
     // Shipping methods collection
     match /shipping_methods/{methodId} {
-      allow read: if true;
-      allow write: if isManagerOrDevelopment();
-    }
-
-    // Payment methods collection (global)
-    match /payment_methods/{methodId} {
       allow read: if true;
       allow write: if isManagerOrDevelopment();
     }


### PR DESCRIPTION
## Summary
- merge repeated `match /settings/{settingId}` blocks
- consolidate global `payment_methods` rules into one section
- scan rules file to confirm no other duplicate paths remain

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching @testing-library/react)*

------
https://chatgpt.com/codex/tasks/task_e_68c69b6610e0832a8eb5e959473f18a1