### PR TITLE
Refactor route handling with ShopRoutes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,63 +1,23 @@
 
 import React, { useState, useEffect, Suspense } from 'react';
 import { useCurrency, detectUserCurrency } from '@/lib/currencyContext.jsx';
-import { BrowserRouter as Router, Routes, Route, useLocation, Navigate } from 'react-router-dom';
-import { motion, AnimatePresence } from 'framer-motion';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { AnimatePresence } from 'framer-motion';
 import { Toaster } from '@/components/ui/toaster';
 import { toast } from '@/components/ui/use-toast.js';
-import Header from '@/components/Header.jsx';
-import Footer from '@/components/Footer.jsx';
-import SEO from '@/components/SEO.jsx';
-import AuthPage from '@/pages/AuthPage.jsx';
 import ErrorBoundary from '@/components/ErrorBoundary.jsx';
 import { useAuth } from '@/lib/authContext.jsx';
 import { useCart } from '@/lib/cartContext.jsx';
 import { useFavorites } from '@/lib/favoritesContext.jsx';
 import { useSettings } from '@/lib/settingsContext.jsx';
 const AdminRoutes = React.lazy(() => import('@/routes/AdminRoutes.jsx'));
-
-import HomePage from '@/pages/HomePage.jsx';
-import BookDetailsPage from '@/pages/BookDetailsPage.jsx';
-import AuthorPage from '@/pages/AuthorPage.jsx';
-import CategoryPage from '@/pages/CategoryPage.jsx';
-import CartPage from '@/pages/CartPage.jsx';
-import CheckoutPage from '@/pages/CheckoutPage.jsx';
-import UserProfilePage from '@/pages/UserProfilePage.jsx';
-import OrderDetailsPage from '@/pages/OrderDetailsPage.jsx';
-import DashboardOrderDetailsPage from '@/pages/DashboardOrderDetailsPage.jsx';
-import TrackOrderPage from '@/pages/TrackOrderPage.jsx';
-import NotFoundPage from '@/pages/NotFoundPage.jsx';
-import AudiobookPage from '@/pages/AudiobookPage.jsx';
-import EbookPage from '@/pages/EbookPage.jsx';
-import ReadSamplePage from '@/pages/ReadSamplePage.jsx';
-import ListenSamplePage from '@/pages/ListenSamplePage.jsx';
-import EbookReaderPage from '@/pages/EbookReaderPage.jsx';
-import AudiobookPlayerPage from '@/pages/AudiobookPlayerPage.jsx';
-import SubscriptionCheckoutPage from '@/pages/SubscriptionCheckoutPage.jsx';
-import SearchResultsPage from '@/pages/SearchResultsPage.jsx';
-import PrivacyPolicyPage from '@/pages/PrivacyPolicyPage.jsx';
-import TermsOfServicePage from '@/pages/TermsOfServicePage.jsx';
-import ReturnPolicyPage from '@/pages/ReturnPolicyPage.jsx';
-import AuthorsSectionPage from '@/pages/AuthorsSectionPage.jsx';
-import DesignServicesPage from '@/pages/DesignServicesPage.jsx';
-import PublishingServicesPage from '@/pages/PublishingServicesPage.jsx';
-import PublishPage from '@/pages/PublishPage.jsx';
-import AboutPage from '@/pages/AboutPage.jsx';
-import TeamPage from '@/pages/TeamPage.jsx';
-import BlogPage from '@/pages/BlogPage.jsx';
-import BlogDetailsPage from '@/pages/BlogDetailsPage.jsx';
-import BlogTestPage from '@/pages/BlogTestPage.jsx';
-import HelpCenterPage from '@/pages/HelpCenterPage.jsx';
-import DistributorsPage from '@/pages/DistributorsPage.jsx';
-import StoreSettingsPage from '@/pages/StoreSettingsPage.jsx';
+const ShopRoutes = React.lazy(() => import('@/routes/ShopRoutes.jsx'));
 import AddToCartDialog from '@/components/AddToCartDialog.jsx';
 import ScrollToTop from '@/components/ScrollToTop.jsx';
 import ChatWidget from '@/components/ChatWidget.jsx';
 import SplashScreen from '@/components/SplashScreen.jsx';
-import MobileBottomNav from '@/components/MobileBottomNav.jsx';
-import RequireAdmin from '@/components/RequireAdmin.jsx';
 
-import { sellers as initialSellers, branches as initialBranches, footerLinks, paymentMethods as initialPaymentMethods } from '@/data/siteData.js';
+import { sellers as initialSellers, branches as initialBranches, paymentMethods as initialPaymentMethods } from '@/data/siteData.js';
 import api from '@/lib/api.js';
 import { TrendingUp, BookOpen, Users, DollarSign, Eye } from 'lucide-react';
 import { useLanguage, defaultLanguages } from '@/lib/languageContext.jsx';
@@ -521,53 +481,6 @@ const App = () => {
     });
   };
 
-  const PageLayout = ({ children, siteSettings }) => {
-    const location = useLocation();
-    return (
-      <motion.div
-        key={location.pathname}
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        transition={{ duration: 0.3 }}
-      >
-        {React.Children.map(children, child => {
-          if (React.isValidElement(child)) {
-            return React.cloneElement(child, { siteSettings });
-          }
-          return child;
-        })}
-      </motion.div>
-    );
-  };
-  
-  const MainLayout = ({ children, siteSettings }) => (
-    <>
-      <SEO
-        title={siteSettings.siteName}
-        description={siteSettings.description}
-        keywords="كتب, متجر كتب, كتب صوتية, كتب إلكترونية, دار نشر"
-      />
-      <div className="min-h-screen bg-slate-100 text-gray-800">
-        <Header
-          handleFeatureClick={handleFeatureClick}
-          books={books}
-          categories={categoriesState}
-          siteSettings={siteSettings}
-        />
-        <div className="pb-16 md:pb-0">
-          {children}
-        </div>
-        <Footer
-          footerLinks={footerLinks}
-          handleFeatureClick={handleFeatureClick}
-          siteSettings={siteSettings}
-        />
-        <MobileBottomNav />
-      </div>
-    </>
-  );
-
   if (isAppLoading) {
     return <SplashScreen siteSettings={siteSettingsState} />;
   }
@@ -579,153 +492,88 @@ const App = () => {
         <div className="font-sans" dir="rtl">
           <AnimatePresence mode="wait">
             <Suspense fallback={<div>Loading...</div>}>
-            <Routes>
-              <Route
-                path="/admin/*"
-                element={
-                  <AdminRoutes
-                    dashboardProps={{
-                      dashboardStats: dashboardStatsState,
-                      books,
-                      authors,
-                      sellers,
-                      branches,
-                      categories: categoriesState,
-                      orders,
-                      payments,
-                      paymentMethods,
-                      plans,
-                      subscriptions,
-                      dashboardSection,
-                      setDashboardSection,
-                      handleFeatureClick,
-                      setBooks,
-                      setAuthors,
-                      setSellers,
-                      setBranches,
-                      setCategories: setCategoriesState,
-                      setOrders,
-                      setPayments,
-                      setPaymentMethods,
-                      currencies: currenciesState,
-                      setCurrencies: setCurrenciesState,
-                      languages,
-                      setLanguages,
-                      setPlans,
-                      setSubscriptions,
-                      users,
-                      setUsers,
-                      messages,
-                      setMessages,
-                      notifications,
-                      setNotifications,
-                      siteSettings: siteSettingsState,
-                      setSiteSettings: setSiteSettingsState,
-                      sliders: heroSlidesState,
-                      setSliders: setHeroSlidesState,
-                      banners: bannersState,
-                      setBanners: setBannersState,
-                      features,
-                      setFeatures
-                    }}
-                  />
-                }
-              />
-              <Route
-                path="/login"
-                element={
-                  isCustomerLoggedIn ? (
-                    <Navigate to="/profile" />
-                  ) : (
-                    <MainLayout siteSettings={siteSettingsState}>
-                      <PageLayout siteSettings={siteSettingsState}>
-                        <AuthPage onLogin={login} />
-                      </PageLayout>
-                    </MainLayout>
-                  )
-                }
-              />
-              <Route path="/" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><HomePage books={books} authors={authors} heroSlides={heroSlidesState} banners={bannersState} categories={categoriesState} recentSearchBooks={recentSearchBooks} bestsellerBooks={bestsellerBooks} featuresData={features} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
-              <Route path="/book/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><BookDetailsPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} onOpenChat={handleOpenChat} /></PageLayout></MainLayout>} />
-              <Route path="/author/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><AuthorPage authors={authors} books={books} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} /></PageLayout></MainLayout>} />
-              <Route path="/search" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><SearchResultsPage books={books} categories={categoriesState} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} /></PageLayout></MainLayout>} />
-              <Route path="/category/:categoryId" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><CategoryPage books={books} categories={categoriesState} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} /></PageLayout></MainLayout>} />
-              <Route path="/cart" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><CartPage cart={cart} handleRemoveFromCart={handleRemoveFromCart} handleUpdateQuantity={handleUpdateQuantity} /></PageLayout></MainLayout>} />
-              <Route
-                path="/checkout"
-                element={
-                  isCustomerLoggedIn ? (
-                    <MainLayout siteSettings={siteSettingsState}>
-                      <PageLayout siteSettings={siteSettingsState}>
-                        <CheckoutPage
-                          cart={cart}
-                          setCart={setCart}
-                          setOrders={setOrders}
-                          currentUser={currentUser}
-                        />
-                      </PageLayout>
-                    </MainLayout>
-                  ) : (
-                    <Navigate to="/login" />
-                  )
-                }
-              />
-              <Route
-                path="/subscribe/:planId"
-                element={
-                  isCustomerLoggedIn ? (
-                    <MainLayout siteSettings={siteSettingsState}>
-                      <PageLayout siteSettings={siteSettingsState}>
-                        <SubscriptionCheckoutPage />
-                      </PageLayout>
-                    </MainLayout>
-                  ) : (
-                    <Navigate to="/login" />
-                  )
-                }
-              />
-              <Route
-                path="/profile"
-                element={
-                  isCustomerLoggedIn ? (
-                    <MainLayout siteSettings={siteSettingsState}>
-                      <PageLayout siteSettings={siteSettingsState}>
-                        <UserProfilePage 
-                          handleFeatureClick={handleFeatureClick}
-                          currentUser={currentUser}
-                        />
-                      </PageLayout>
-                    </MainLayout>
-                  ) : (
-                    <Navigate to="/login" />
-                  )
-                }
-              />
-              <Route path="/orders/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><OrderDetailsPage /></PageLayout></MainLayout>} />
-              <Route path="/track-order" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><TrackOrderPage /></PageLayout></MainLayout>} />
-              <Route path="/ebooks" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><EbookPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} wishlist={wishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
-              <Route path="/audiobooks" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><AudiobookPage books={books} authors={authors} handleAddToCart={handleAddToCart} handleToggleWishlist={handleToggleWishlist} wishlist={wishlist} handleFeatureClick={handleFeatureClick} /></PageLayout></MainLayout>} />
-              <Route path="/read/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><ReadSamplePage books={books} /></PageLayout></MainLayout>} />
-              <Route path="/reader/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><EbookReaderPage books={books} /></PageLayout></MainLayout>} />
-              <Route path="/listen/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><ListenSamplePage books={books} /></PageLayout></MainLayout>} />
-              <Route path="/player/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><AudiobookPlayerPage books={books} /></PageLayout></MainLayout>} />
-              <Route path="/privacy-policy" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><PrivacyPolicyPage /></PageLayout></MainLayout>} />
-              <Route path="/terms-of-service" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><TermsOfServicePage /></PageLayout></MainLayout>} />
-              <Route path="/return-policy" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><ReturnPolicyPage /></PageLayout></MainLayout>} />
-              <Route path="/authors" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><AuthorsSectionPage /></PageLayout></MainLayout>} />
-              <Route path="/design-services" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><DesignServicesPage /></PageLayout></MainLayout>} />
-              <Route path="/publishing-services" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><PublishingServicesPage /></PageLayout></MainLayout>} />
-              <Route path="/publish" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><PublishPage /></PageLayout></MainLayout>} />
-              <Route path="/about" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><AboutPage /></PageLayout></MainLayout>} />
-              <Route path="/team" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><TeamPage /></PageLayout></MainLayout>} />
-              <Route path="/blog" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><BlogPage /></PageLayout></MainLayout>} />
-              <Route path="/blog/:id" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><BlogDetailsPage /></PageLayout></MainLayout>} />
-              <Route path="/blog-test" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><BlogTestPage /></PageLayout></MainLayout>} />
-              <Route path="/help" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><HelpCenterPage /></PageLayout></MainLayout>} />
-              <Route path="/distributors" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><DistributorsPage /></PageLayout></MainLayout>} />
-<Route path="/store-settings" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><StoreSettingsPage /></PageLayout></MainLayout>} />
-<Route path="*" element={<MainLayout siteSettings={siteSettingsState}><PageLayout siteSettings={siteSettingsState}><NotFoundPage /></PageLayout></MainLayout>} />
-            </Routes>
+              <Routes>
+                <Route
+                  path="/admin/*"
+                  element={
+                    <AdminRoutes
+                      dashboardProps={{
+                        dashboardStats: dashboardStatsState,
+                        books,
+                        authors,
+                        sellers,
+                        branches,
+                        categories: categoriesState,
+                        orders,
+                        payments,
+                        paymentMethods,
+                        plans,
+                        subscriptions,
+                        dashboardSection,
+                        setDashboardSection,
+                        handleFeatureClick,
+                        setBooks,
+                        setAuthors,
+                        setSellers,
+                        setBranches,
+                        setCategories: setCategoriesState,
+                        setOrders,
+                        setPayments,
+                        setPaymentMethods,
+                        currencies: currenciesState,
+                        setCurrencies: setCurrenciesState,
+                        languages,
+                        setLanguages,
+                        setPlans,
+                        setSubscriptions,
+                        users,
+                        setUsers,
+                        messages,
+                        setMessages,
+                        notifications,
+                        setNotifications,
+                        siteSettings: siteSettingsState,
+                        setSiteSettings: setSiteSettingsState,
+                        sliders: heroSlidesState,
+                        setSliders: setHeroSlidesState,
+                        banners: bannersState,
+                        setBanners: setBannersState,
+                        features,
+                        setFeatures
+                      }}
+                    />
+                  }
+                />
+                <Route
+                  path="/*"
+                  element={
+                    <ShopRoutes
+                      isCustomerLoggedIn={isCustomerLoggedIn}
+                      login={login}
+                      currentUser={currentUser}
+                      books={books}
+                      authors={authors}
+                      categories={categoriesState}
+                      cart={cart}
+                      setCart={setCart}
+                      setOrders={setOrders}
+                      handleAddToCart={handleAddToCart}
+                      handleRemoveFromCart={handleRemoveFromCart}
+                      handleUpdateQuantity={handleUpdateQuantity}
+                      handleToggleWishlist={handleToggleWishlist}
+                      handleFeatureClick={handleFeatureClick}
+                      handleOpenChat={handleOpenChat}
+                      recentSearchBooks={recentSearchBooks}
+                      bestsellerBooks={bestsellerBooks}
+                      heroSlides={heroSlidesState}
+                      banners={bannersState}
+                      wishlist={wishlist}
+                      siteSettings={siteSettingsState}
+                      features={features}
+                    />
+                  }
+                />
+              </Routes>
             </Suspense>
           </AnimatePresence>
           <Toaster />

--- a/src/routes/ShopRoutes.jsx
+++ b/src/routes/ShopRoutes.jsx
@@ -1,0 +1,535 @@
+import React, { Suspense } from 'react';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import Header from '@/components/Header.jsx';
+import Footer from '@/components/Footer.jsx';
+import SEO from '@/components/SEO.jsx';
+import MobileBottomNav from '@/components/MobileBottomNav.jsx';
+import { footerLinks } from '@/data/siteData.js';
+
+const AuthPage = React.lazy(() => import('@/pages/AuthPage.jsx'));
+const HomePage = React.lazy(() => import('@/pages/HomePage.jsx'));
+const BookDetailsPage = React.lazy(() => import('@/pages/BookDetailsPage.jsx'));
+const AuthorPage = React.lazy(() => import('@/pages/AuthorPage.jsx'));
+const CategoryPage = React.lazy(() => import('@/pages/CategoryPage.jsx'));
+const CartPage = React.lazy(() => import('@/pages/CartPage.jsx'));
+const CheckoutPage = React.lazy(() => import('@/pages/CheckoutPage.jsx'));
+const UserProfilePage = React.lazy(() => import('@/pages/UserProfilePage.jsx'));
+const OrderDetailsPage = React.lazy(() => import('@/pages/OrderDetailsPage.jsx'));
+const TrackOrderPage = React.lazy(() => import('@/pages/TrackOrderPage.jsx'));
+const AudiobookPage = React.lazy(() => import('@/pages/AudiobookPage.jsx'));
+const EbookPage = React.lazy(() => import('@/pages/EbookPage.jsx'));
+const ReadSamplePage = React.lazy(() => import('@/pages/ReadSamplePage.jsx'));
+const ListenSamplePage = React.lazy(() => import('@/pages/ListenSamplePage.jsx'));
+const EbookReaderPage = React.lazy(() => import('@/pages/EbookReaderPage.jsx'));
+const AudiobookPlayerPage = React.lazy(() => import('@/pages/AudiobookPlayerPage.jsx'));
+const SubscriptionCheckoutPage = React.lazy(() => import('@/pages/SubscriptionCheckoutPage.jsx'));
+const SearchResultsPage = React.lazy(() => import('@/pages/SearchResultsPage.jsx'));
+const PrivacyPolicyPage = React.lazy(() => import('@/pages/PrivacyPolicyPage.jsx'));
+const TermsOfServicePage = React.lazy(() => import('@/pages/TermsOfServicePage.jsx'));
+const ReturnPolicyPage = React.lazy(() => import('@/pages/ReturnPolicyPage.jsx'));
+const AuthorsSectionPage = React.lazy(() => import('@/pages/AuthorsSectionPage.jsx'));
+const DesignServicesPage = React.lazy(() => import('@/pages/DesignServicesPage.jsx'));
+const PublishingServicesPage = React.lazy(() => import('@/pages/PublishingServicesPage.jsx'));
+const PublishPage = React.lazy(() => import('@/pages/PublishPage.jsx'));
+const AboutPage = React.lazy(() => import('@/pages/AboutPage.jsx'));
+const TeamPage = React.lazy(() => import('@/pages/TeamPage.jsx'));
+const BlogPage = React.lazy(() => import('@/pages/BlogPage.jsx'));
+const BlogDetailsPage = React.lazy(() => import('@/pages/BlogDetailsPage.jsx'));
+const BlogTestPage = React.lazy(() => import('@/pages/BlogTestPage.jsx'));
+const HelpCenterPage = React.lazy(() => import('@/pages/HelpCenterPage.jsx'));
+const DistributorsPage = React.lazy(() => import('@/pages/DistributorsPage.jsx'));
+const StoreSettingsPage = React.lazy(() => import('@/pages/StoreSettingsPage.jsx'));
+const NotFoundPage = React.lazy(() => import('@/pages/NotFoundPage.jsx'));
+
+const ShopRoutes = ({
+  isCustomerLoggedIn,
+  login,
+  currentUser,
+  books,
+  authors,
+  categories,
+  cart,
+  setCart,
+  setOrders,
+  handleAddToCart,
+  handleRemoveFromCart,
+  handleUpdateQuantity,
+  handleToggleWishlist,
+  handleFeatureClick,
+  handleOpenChat,
+  recentSearchBooks,
+  bestsellerBooks,
+  heroSlides,
+  banners,
+  wishlist,
+  siteSettings,
+  features
+}) => {
+  const PageLayout = ({ children }) => {
+    const location = useLocation();
+    return (
+      <motion.div
+        key={location.pathname}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.3 }}
+      >
+        {React.Children.map(children, child =>
+          React.isValidElement(child) ? React.cloneElement(child, { siteSettings }) : child
+        )}
+      </motion.div>
+    );
+  };
+
+  const MainLayout = ({ children }) => (
+    <>
+      <SEO
+        title={siteSettings.siteName}
+        description={siteSettings.description}
+        keywords="كتب, متجر كتب, كتب صوتية, كتب إلكترونية, دار نشر"
+      />
+      <div className="min-h-screen bg-slate-100 text-gray-800">
+        <Header
+          handleFeatureClick={handleFeatureClick}
+          books={books}
+          categories={categories}
+          siteSettings={siteSettings}
+        />
+        <div className="pb-16 md:pb-0">{children}</div>
+        <Footer
+          footerLinks={footerLinks}
+          handleFeatureClick={handleFeatureClick}
+          siteSettings={siteSettings}
+        />
+        <MobileBottomNav />
+      </div>
+    </>
+  );
+
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Routes>
+        <Route
+          path="/login"
+          element={
+            isCustomerLoggedIn ? (
+              <Navigate to="/profile" />
+            ) : (
+              <MainLayout>
+                <PageLayout>
+                  <AuthPage onLogin={login} />
+                </PageLayout>
+              </MainLayout>
+            )
+          }
+        />
+        <Route
+          path="/"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <HomePage
+                  books={books}
+                  authors={authors}
+                  heroSlides={heroSlides}
+                  banners={banners}
+                  categories={categories}
+                  recentSearchBooks={recentSearchBooks}
+                  bestsellerBooks={bestsellerBooks}
+                  featuresData={features}
+                  handleAddToCart={handleAddToCart}
+                  handleToggleWishlist={handleToggleWishlist}
+                  handleFeatureClick={handleFeatureClick}
+                />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/book/:id"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <BookDetailsPage
+                  books={books}
+                  authors={authors}
+                  handleAddToCart={handleAddToCart}
+                  handleToggleWishlist={handleToggleWishlist}
+                  onOpenChat={handleOpenChat}
+                />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/author/:id"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <AuthorPage
+                  authors={authors}
+                  books={books}
+                  handleAddToCart={handleAddToCart}
+                  handleToggleWishlist={handleToggleWishlist}
+                />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/search"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <SearchResultsPage
+                  books={books}
+                  categories={categories}
+                  handleAddToCart={handleAddToCart}
+                  handleToggleWishlist={handleToggleWishlist}
+                />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/category/:categoryId"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <CategoryPage
+                  books={books}
+                  categories={categories}
+                  handleAddToCart={handleAddToCart}
+                  handleToggleWishlist={handleToggleWishlist}
+                />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/cart"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <CartPage
+                  cart={cart}
+                  handleRemoveFromCart={handleRemoveFromCart}
+                  handleUpdateQuantity={handleUpdateQuantity}
+                />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/checkout"
+          element={
+            isCustomerLoggedIn ? (
+              <MainLayout>
+                <PageLayout>
+                  <CheckoutPage
+                    cart={cart}
+                    setCart={setCart}
+                    setOrders={setOrders}
+                    currentUser={currentUser}
+                  />
+                </PageLayout>
+              </MainLayout>
+            ) : (
+              <Navigate to="/login" />
+            )
+          }
+        />
+        <Route
+          path="/subscribe/:planId"
+          element={
+            isCustomerLoggedIn ? (
+              <MainLayout>
+                <PageLayout>
+                  <SubscriptionCheckoutPage />
+                </PageLayout>
+              </MainLayout>
+            ) : (
+              <Navigate to="/login" />
+            )
+          }
+        />
+        <Route
+          path="/profile"
+          element={
+            isCustomerLoggedIn ? (
+              <MainLayout>
+                <PageLayout>
+                  <UserProfilePage
+                    handleFeatureClick={handleFeatureClick}
+                    currentUser={currentUser}
+                  />
+                </PageLayout>
+              </MainLayout>
+            ) : (
+              <Navigate to="/login" />
+            )
+          }
+        />
+        <Route
+          path="/orders/:id"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <OrderDetailsPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/track-order"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <TrackOrderPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/ebooks"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <EbookPage
+                  books={books}
+                  authors={authors}
+                  handleAddToCart={handleAddToCart}
+                  handleToggleWishlist={handleToggleWishlist}
+                  wishlist={wishlist}
+                  handleFeatureClick={handleFeatureClick}
+                />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/audiobooks"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <AudiobookPage
+                  books={books}
+                  authors={authors}
+                  handleAddToCart={handleAddToCart}
+                  handleToggleWishlist={handleToggleWishlist}
+                  wishlist={wishlist}
+                  handleFeatureClick={handleFeatureClick}
+                />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/read/:id"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <ReadSamplePage books={books} />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/reader/:id"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <EbookReaderPage books={books} />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/listen/:id"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <ListenSamplePage books={books} />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/player/:id"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <AudiobookPlayerPage books={books} />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/privacy-policy"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <PrivacyPolicyPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/terms-of-service"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <TermsOfServicePage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/return-policy"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <ReturnPolicyPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/authors"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <AuthorsSectionPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/design-services"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <DesignServicesPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/publishing-services"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <PublishingServicesPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/publish"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <PublishPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/about"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <AboutPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/team"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <TeamPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/blog"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <BlogPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/blog/:id"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <BlogDetailsPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/blog-test"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <BlogTestPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/help"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <HelpCenterPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/distributors"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <DistributorsPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/store-settings"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <StoreSettingsPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="*"
+          element={
+            <MainLayout>
+              <PageLayout>
+                <NotFoundPage />
+              </PageLayout>
+            </MainLayout>
+          }
+        />
+      </Routes>
+    </Suspense>
+  );
+};
+
+export default ShopRoutes;
+


### PR DESCRIPTION
## Summary
- refactor `App.jsx` to lazy load route groups and delegate public routes to a new `ShopRoutes` component
- add `ShopRoutes.jsx` with lazy-loaded pages wrapped in Suspense for the storefront

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a4b8d720832a83d0787667522b02