### PR TITLE
chore: enable default console warnings

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -176,8 +176,6 @@ const addTransformIndexHtml = {
 	},
 };
 
-console.warn = () => {};
-
 const logger = createLogger()
 const loggerError = logger.error
 


### PR DESCRIPTION
## Summary
- remove console.warn override in Vite config to surface warnings

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b8adedac832a823ccd7d69f6876b