### PR TITLE
Add encryption utilities to PaymentProvider

### DIFF
--- a/tests/paymentProviderEncryption.test.js
+++ b/tests/paymentProviderEncryption.test.js
@@ -1,0 +1,20 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/lib/logger.js', () => ({
+  default: { debug: jest.fn(), info: jest.fn(), error: jest.fn() }
+}));
+
+const { PaymentProvider } = await import('../src/lib/payment/providers/PaymentProvider.js');
+
+describe('PaymentProvider encryption', () => {
+  const encryptionKey = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+  test('encrypts and decrypts data correctly', () => {
+    const provider = new PaymentProvider({ encryptionKey });
+    const data = { secret: 'value', number: 123 };
+    const encrypted = provider.encryptSensitiveData(data);
+    expect(encrypted).not.toEqual(JSON.stringify(data));
+    const decrypted = provider.decryptSensitiveData(encrypted);
+    expect(decrypted).toEqual(data);
+  });
+});


### PR DESCRIPTION
## Summary
- integrate Node.js crypto for encrypting and decrypting sensitive data in payment providers
- add unit test to verify PaymentProvider encryption flow

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b95a81e4832a801e38c04223e66f