### PR TITLE
Add tests for payment manager and services

### DIFF
--- a/tests/paymentManager.test.js
+++ b/tests/paymentManager.test.js
@@ -1,0 +1,79 @@
+import { jest } from '@jest/globals';
+
+const createProviderMock = (name) => {
+  const initialize = jest.fn().mockResolvedValue({});
+  const getProviderInfo = jest.fn().mockReturnValue({
+    supportedCurrencies: ['SAR'],
+    supportedCountries: ['SA'],
+    supportedPaymentMethods: [],
+  });
+  const Provider = jest.fn().mockImplementation(() => ({
+    providerName: name,
+    initialize,
+    getProviderInfo,
+  }));
+  return { Provider, initialize };
+};
+
+const stripe = createProviderMock('stripe');
+const paypal = createProviderMock('paypal');
+const tabby = createProviderMock('tabby');
+const cod = createProviderMock('cash_on_delivery');
+
+jest.mock('../src/lib/payment/providers/StripeProvider.js', () => ({
+  StripeProvider: stripe.Provider,
+}));
+jest.mock('../src/lib/payment/providers/PayPalProvider.js', () => ({
+  PayPalProvider: paypal.Provider,
+}));
+jest.mock('../src/lib/payment/providers/TabbyProvider.js', () => ({
+  TabbyProvider: tabby.Provider,
+}));
+jest.mock('../src/lib/payment/providers/CashOnDeliveryProvider.js', () => ({
+  CashOnDeliveryProvider: cod.Provider,
+}));
+
+import { PaymentManager } from '../src/lib/payment/PaymentManager.js';
+
+describe('PaymentManager provider initialization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('initializes providers and selects stripe as active provider', async () => {
+    const manager = new PaymentManager();
+    const settings = {
+      stripe: { publishableKey: 'pk', secretKey: 'sk' },
+      paypal: { clientId: 'id', clientSecret: 'secret' },
+      tabby: { apiKey: 'ak', secretKey: 'sk' },
+      cashOnDelivery: { maxAmount: 1000, codFee: 15 },
+    };
+
+    await manager.initialize(settings);
+
+    expect(stripe.Provider).toHaveBeenCalled();
+    expect(paypal.Provider).toHaveBeenCalled();
+    expect(tabby.Provider).toHaveBeenCalled();
+    expect(cod.Provider).toHaveBeenCalled();
+
+    expect(stripe.initialize).toHaveBeenCalled();
+    expect(paypal.initialize).toHaveBeenCalled();
+    expect(tabby.initialize).toHaveBeenCalled();
+    expect(cod.initialize).toHaveBeenCalled();
+
+    expect(manager.activeProvider.providerName).toBe('stripe');
+  });
+
+  test('selects paypal as active provider when stripe is unavailable', async () => {
+    const manager = new PaymentManager();
+    const settings = {
+      paypal: { clientId: 'id', clientSecret: 'secret' },
+      cashOnDelivery: {},
+    };
+
+    await manager.initialize(settings);
+
+    expect(stripe.Provider).not.toHaveBeenCalled();
+    expect(manager.activeProvider.providerName).toBe('paypal');
+  });
+});

--- a/tests/paymentService.test.js
+++ b/tests/paymentService.test.js
@@ -22,6 +22,13 @@ describe('PaymentService real payment flow', () => {
     jest.clearAllMocks();
   });
 
+  test('createPayment fails validation with missing fields', async () => {
+    const service = new PaymentService();
+    await expect(service.createPayment({ orderId: 'o1' }))
+      .rejects.toEqual(expect.objectContaining({ code: 'validation/payment-invalid' }));
+    expect(paymentManager.createPaymentIntent).not.toHaveBeenCalled();
+  });
+
   test('processPayment succeeds and updates status with gateway result', async () => {
     const service = new PaymentService();
     paymentManager.createPaymentIntent.mockResolvedValue({

--- a/tests/shippingService.test.js
+++ b/tests/shippingService.test.js
@@ -1,0 +1,43 @@
+import { jest } from '@jest/globals';
+import { ShippingService } from '../src/lib/services/ShippingService.js';
+import firebaseApi from '../src/lib/firebase/baseApi.js';
+
+jest.mock('../src/lib/firebase/baseApi.js', () => ({
+  addToCollection: jest.fn(),
+}));
+
+describe('ShippingService createShipping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('successfully creates shipping with valid data', async () => {
+    firebaseApi.addToCollection.mockResolvedValue({ id: 'ship_1' });
+    const service = new ShippingService();
+    const shippingData = {
+      orderId: 'o1',
+      customerId: 'c1',
+      shippingMethod: 'standard',
+      shippingAddress: {
+        name: 'John',
+        phone: '1234567890',
+        street: 'Main',
+        city: 'Riyadh',
+        country: 'SA'
+      },
+      packageWeight: 2
+    };
+    const result = await service.createShipping(shippingData);
+    expect(firebaseApi.addToCollection).toHaveBeenCalled();
+    expect(result).toHaveProperty('id', 'ship_1');
+    expect(result.shippingCost).toBeGreaterThan(0);
+  });
+
+  test('fails validation when required fields are missing', async () => {
+    const service = new ShippingService();
+    await expect(
+      service.createShipping({ orderId: 'o2', shippingAddress: {} })
+    ).rejects.toEqual(expect.objectContaining({ code: 'validation/shipping-invalid' }));
+    expect(firebaseApi.addToCollection).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for PaymentManager to verify provider initialization and active selection
- cover ShippingService createShipping success and validation errors
- extend PaymentService tests to check validation failure

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2freact)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bc9d95f0832a9c5054d3dcaefbba