### PR TITLE
chore: use rules unit testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "firebase-tools": "^13.0.0",
     "jest": "^29.7.0",
     "@testing-library/react": "^14.0.0",
-    "firebase-testing": "^0.16.8",
+    "@firebase/rules-unit-testing": "^3.0.0",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.3",
     "terser": "^5.39.0",

--- a/tests/firebaseIntegration.test.js
+++ b/tests/firebaseIntegration.test.js
@@ -1,9 +1,18 @@
-import { initializeTestApp, assertSucceeds } from 'firebase-testing';
+import { initializeTestEnvironment, assertSucceeds } from '@firebase/rules-unit-testing';
 
 describe('Firebase emulator integration', () => {
+  let testEnv;
+
+  beforeAll(async () => {
+    testEnv = await initializeTestEnvironment({ projectId: 'demo-test' });
+  });
+
+  afterAll(async () => {
+    await testEnv.cleanup();
+  });
+
   test('writes and reads from firestore emulator', async () => {
-    const app = initializeTestApp({ projectId: 'demo-test' });
-    const db = app.firestore();
+    const db = testEnv.unauthenticatedContext().firestore();
     const ref = db.collection('integration').doc('test');
     await assertSucceeds(ref.set({ foo: 'bar' }));
     const snap = await ref.get();


### PR DESCRIPTION
## Summary
- swap deprecated firebase-testing for @firebase/rules-unit-testing
- refactor firebase emulator test to use new test environment

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@firebase%2frules-unit-testing)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c21420e0832a93f74a78eb0903cb