### PR TITLE
Fix ChatWidget user info lookup

### DIFF
--- a/src/components/ChatWidget.jsx
+++ b/src/components/ChatWidget.jsx
@@ -48,12 +48,18 @@ const ChatWidget = ({
 
   useEffect(() => {
     if (!isLoggedIn || !userId || targetUser) return;
-    api.getUser(userId).then(u => {
-      if (u) {
-        setName(u.name || '');
-        setEmail(u.email || '');
-      }
-    });
+
+    api
+      .getCustomer(userId)
+      .then((u) => {
+        if (u) {
+          setName(u.displayName || '');
+          setEmail(u.email || '');
+        }
+      })
+      .catch((error) => {
+        logger.error('Error fetching customer data:', error);
+      });
   }, [userId, isLoggedIn, targetUser]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fix ChatWidget to use `api.getCustomer` instead of non-existent `api.getUser`
- Pull display name and email from customer record with error logging

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c7a528ec832abc9b135168c8a539