### PR TITLE
feat(firestore): add composite indexes for messages

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -111,6 +111,34 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "email",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- add userId/createdAt and email/createdAt ascending indexes for `messages`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install jest` *(fails: 403 Forbidden from registry)*
- `npm run firebase:deploy:firestore` *(fails: firebase CLI not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6eac24c14832a940ea210977e8879