### PR TITLE
feat: add home page firebase API endpoints

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -12,11 +12,13 @@ import CartService from './services/CartService.js';
 import unifiedPaymentApi from './api/unifiedPaymentApi.js';
 import logger from './logger.js';
 import * as encryptedCache from './encryptedCache.js';
+import homeApi from './firebase/homeApi.js';
 
 // Firebase API هو الآن الخيار الوحيد مع Functions
 const api = {
   ...firebaseApi,
   ...firebaseFunctionsApi,
+  home: homeApi,
 
   // الحصول على الإعدادات مع كاش مشفر اختياري
   getSettings: async (forceRefresh = false) => {

--- a/src/lib/firebase/homeApi.js
+++ b/src/lib/firebase/homeApi.js
@@ -1,0 +1,31 @@
+import baseApi from './baseApi.js';
+
+export const getSliders = () => baseApi.getCollection('sliders');
+export const addSlider = (data) => baseApi.addToCollection('sliders', data);
+export const updateSlider = (id, data) => baseApi.updateCollection('sliders', id, data);
+export const deleteSlider = (id) => baseApi.deleteFromCollection('sliders', id);
+
+export const getBanners = () => baseApi.getCollection('banners');
+export const addBanner = (data) => baseApi.addToCollection('banners', data);
+export const updateBanner = (id, data) => baseApi.updateCollection('banners', id, data);
+export const deleteBanner = (id) => baseApi.deleteFromCollection('banners', id);
+
+export const getFeatures = () => baseApi.getCollection('features');
+export const addFeature = (data) => baseApi.addToCollection('features', data);
+export const updateFeature = (id, data) => baseApi.updateCollection('features', id, data);
+export const deleteFeature = (id) => baseApi.deleteFromCollection('features', id);
+
+export default {
+  getSliders,
+  addSlider,
+  updateSlider,
+  deleteSlider,
+  getBanners,
+  addBanner,
+  updateBanner,
+  deleteBanner,
+  getFeatures,
+  addFeature,
+  updateFeature,
+  deleteFeature
+};

--- a/src/lib/firebaseApi.js
+++ b/src/lib/firebaseApi.js
@@ -5,6 +5,7 @@ import faqApi from './firebase/faqApi.js';
 import messagesApi from './firebase/messagesApi.js';
 import settingsApi from './firebase/settingsApi.js';
 import ratingsApi from './firebase/ratingsApi.js';
+import homeApi from './firebase/homeApi.js';
 
 // Aggregate all domain APIs into a single object for backwards compatibility
 export default {
@@ -14,5 +15,6 @@ export default {
   ...faqApi,
   ...messagesApi,
   ...settingsApi,
-  ...ratingsApi
+  ...ratingsApi,
+  ...homeApi
 };


### PR DESCRIPTION
## Summary
- add homeApi with CRUD helpers for sliders, banners and features
- expose homeApi in firebaseApi aggregate
- expose home API through top-level api object

## Testing
- `npm install jest` (fails: 403 Forbidden)
- `npm test` (fails: jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c6f18d69e0832aba69a04881b54792