### PR TITLE
Add Google Merchant import integration

### DIFF
--- a/functions/googleMerchantImport.js
+++ b/functions/googleMerchantImport.js
@@ -1,0 +1,161 @@
+import functions from 'firebase-functions';
+import admin from 'firebase-admin';
+
+try {
+  admin.app();
+} catch (e) {
+  admin.initializeApp();
+}
+
+const db = admin.firestore();
+
+function clampLimit(limit) {
+  const parsed = Number.parseInt(limit, 10);
+  if (Number.isNaN(parsed)) {
+    return 5;
+  }
+  return Math.max(1, Math.min(parsed, 50));
+}
+
+async function fetchGoogleMerchantCatalog(merchantId, apiKey, limit = 5) {
+  // محاكاة استدعاء Google Merchant API - في بيئة الإنتاج سيتم استبدالها
+  void apiKey; // سيتم استخدامه مع التكامل الحقيقي لاحقاً
+  const safeLimit = clampLimit(limit);
+  const items = Array.from({ length: safeLimit }).map((_, index) => {
+    const idNumber = String(index + 1).padStart(3, '0');
+    return {
+      offerId: `${merchantId}-${idNumber}`,
+      title: `Imported Book ${index + 1}`,
+      description: 'Imported automatically from Google Merchant feed.',
+      price: (39.99 + index).toFixed(2),
+      currency: 'SAR',
+      availability: index % 4 === 0 ? 'out_of_stock' : 'in_stock',
+      link: `https://books.example.com/${merchantId}/book-${idNumber}`,
+      imageLink: `https://images.example.com/${merchantId}/book-${idNumber}.jpg`
+    };
+  });
+
+  return { items };
+}
+
+function sanitiseCatalogItems(rawItems = [], merchantId) {
+  const items = [];
+  const warnings = [];
+
+  rawItems.forEach((item, index) => {
+    const offerId = (item.offerId || item.id || `${merchantId}-${index + 1}`).toString();
+    const title = typeof item.title === 'string' ? item.title.trim() : '';
+
+    if (!title) {
+      warnings.push({
+        code: 'missing-title',
+        offerId,
+        message: `Item ${offerId} is missing a title and was skipped.`
+      });
+      return;
+    }
+
+    const rawPrice = typeof item.price === 'object' ? item.price.value || item.price.amount : item.price;
+    const price = Number.parseFloat(rawPrice);
+
+    if (!Number.isFinite(price) || price <= 0) {
+      warnings.push({
+        code: 'invalid-price',
+        offerId,
+        message: `Item "${title}" has an invalid price and was skipped.`
+      });
+      return;
+    }
+
+    const currency = (item.currency || item.priceCurrency || item.price?.currency || 'SAR').toUpperCase();
+
+    items.push({
+      offerId,
+      merchantId,
+      title,
+      description: typeof item.description === 'string' ? item.description.trim() : '',
+      price: Math.round(price * 100) / 100,
+      currency,
+      availability: item.availability || item.stockStatus || 'in_stock',
+      link: item.link || item.productLink || null,
+      imageLink: item.imageLink || item.image || null
+    });
+  });
+
+  return {
+    items,
+    warnings,
+    skippedCount: rawItems.length - items.length
+  };
+}
+
+export const importGoogleMerchantCatalog = functions.https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', 'User must be authenticated to import Google Merchant data.');
+  }
+
+  const { googleMerchantId, googleApiKey, options = {} } = data || {};
+  const merchantId = typeof googleMerchantId === 'string' ? googleMerchantId.trim() : '';
+  const apiKey = typeof googleApiKey === 'string' ? googleApiKey.trim() : '';
+  const dryRun = Boolean(options.dryRun);
+  const limit = clampLimit(options.limit ?? 5);
+
+  if (!merchantId) {
+    throw new functions.https.HttpsError('invalid-argument', 'googleMerchantId is required.');
+  }
+
+  if (!apiKey) {
+    throw new functions.https.HttpsError('invalid-argument', 'googleApiKey is required.');
+  }
+
+  try {
+    const catalog = await fetchGoogleMerchantCatalog(merchantId, apiKey, limit);
+    const { items, warnings, skippedCount } = sanitiseCatalogItems(catalog.items, merchantId);
+
+    const response = {
+      success: true,
+      importedCount: items.length,
+      skippedCount,
+      warnings,
+      dryRun,
+      preview: items.slice(0, 10)
+    };
+
+    if (!dryRun) {
+      const merchantRoot = db.collection('integrations').doc('googleMerchant');
+      const batch = db.batch();
+
+      items.forEach((item) => {
+        const docRef = merchantRoot.collection('catalog').doc(item.offerId);
+        batch.set(docRef, {
+          ...item,
+          updatedAt: admin.firestore.FieldValue.serverTimestamp()
+        }, { merge: true });
+      });
+
+      const logRef = merchantRoot.collection('imports').doc();
+      batch.set(logRef, {
+        merchantId,
+        importedCount: items.length,
+        skippedCount,
+        warnings,
+        dryRun,
+        triggeredBy: context.auth.uid || null,
+        requestedAt: admin.firestore.FieldValue.serverTimestamp()
+      });
+
+      await batch.commit();
+    }
+
+    return response;
+  } catch (error) {
+    console.error('Google Merchant import failed', error);
+    if (error instanceof functions.https.HttpsError) {
+      throw error;
+    }
+    throw new functions.https.HttpsError(
+      'internal',
+      error.message || 'Failed to import Google Merchant catalog.'
+    );
+  }
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -14,6 +14,7 @@ const db = admin.firestore();
 
 export { syncPaymentStatus, syncShippingStatus } from './statusSync.js';
 export { handlePaymentWebhook, handleShipmentWebhook, checkPendingOrders } from './orderLifecycleService.js';
+export { importGoogleMerchantCatalog } from './googleMerchantImport.js';
 
 // ===== PAYMENT FUNCTIONS =====
 

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -39,11 +39,22 @@ const api = {
 
   // Google Merchant import - سيتم تنفيذها عبر Firebase Functions
   importGoogleMerchant: async (cfg = {}) => {
+    const context = 'google-merchant:import';
     try {
-      // TODO: تنفيذ عبر Firebase Functions
-      throw new Error('Google Merchant import سيتم تنفيذها قريباً عبر Firebase Functions');
+      const result = await firebaseFunctionsApi.googleMerchant.importCatalog(cfg);
+
+      if (!result?.success) {
+        throw errorHandler.createError(
+          errorHandler.errorTypes.UNKNOWN,
+          result?.errorCode || 'google-merchant/import-failed',
+          result?.message || 'فشل استيراد Google Merchant',
+          context
+        );
+      }
+
+      return result;
     } catch (error) {
-      throw errorHandler.handleError(error, 'google-merchant:import');
+      throw errorHandler.handleError(error, context);
     }
   },
 

--- a/src/lib/firebaseFunctions.js
+++ b/src/lib/firebaseFunctions.js
@@ -8,6 +8,9 @@ const functions = getFunctions();
 export const createStripePaymentIntent = httpsCallable(functions, 'createStripePaymentIntent');
 export const createPayPalOrder = httpsCallable(functions, 'createPayPalOrder');
 
+// Google Merchant Functions
+export const importGoogleMerchantCatalog = httpsCallable(functions, 'importGoogleMerchantCatalog');
+
 // Order Functions
 export const processOrder = httpsCallable(functions, 'processOrder');
 
@@ -108,6 +111,19 @@ export const firebaseFunctionsApi = {
         return result.data;
       } catch (error) {
         logger.error('Access Validation Error:', error);
+        throw error;
+      }
+    }
+  },
+
+  // Google Merchant operations
+  googleMerchant: {
+    importCatalog: async (config) => {
+      try {
+        const result = await importGoogleMerchantCatalog(config);
+        return result.data;
+      } catch (error) {
+        logger.error('Google Merchant import error:', error);
         throw error;
       }
     }

--- a/tests/googleMerchantImport.test.js
+++ b/tests/googleMerchantImport.test.js
@@ -1,0 +1,91 @@
+import { jest } from '@jest/globals';
+
+// Mock Firebase core module to avoid requiring environment configuration
+jest.mock('../src/lib/firebase.js', () => ({
+  __esModule: true,
+  db: {},
+  auth: {},
+  storage: {},
+  default: {}
+}));
+
+const importCatalogMock = jest.fn();
+
+const mockFirebaseFunctionsApi = {
+  payments: {
+    createStripeIntent: jest.fn(),
+    createPayPalOrder: jest.fn()
+  },
+  orders: {
+    process: jest.fn()
+  },
+  shipping: {
+    calculate: jest.fn()
+  },
+  inventory: {
+    updateStock: jest.fn()
+  },
+  analytics: {
+    getDashboardStats: jest.fn()
+  },
+  security: {
+    validateAccess: jest.fn()
+  },
+  googleMerchant: {
+    importCatalog: importCatalogMock
+  }
+};
+
+jest.mock('../src/lib/firebaseFunctions.js', () => ({
+  __esModule: true,
+  default: mockFirebaseFunctionsApi,
+  firebaseFunctionsApi: mockFirebaseFunctionsApi,
+  importGoogleMerchantCatalog: importCatalogMock
+}));
+
+import api from '../src/lib/api.js';
+
+describe('api.importGoogleMerchant', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    importCatalogMock.mockReset();
+  });
+
+  test('returns the result when the Cloud Function succeeds', async () => {
+    const payload = { success: true, importedCount: 3, preview: [] };
+    importCatalogMock.mockResolvedValue(payload);
+
+    const config = { googleMerchantId: '123', googleApiKey: 'secret' };
+    const result = await api.importGoogleMerchant(config);
+
+    expect(importCatalogMock).toHaveBeenCalledWith(config);
+    expect(result).toEqual(payload);
+  });
+
+  test('throws a handled error when the Cloud Function reports failure', async () => {
+    importCatalogMock.mockResolvedValue({
+      success: false,
+      message: 'Invalid credentials',
+      errorCode: 'google-merchant/invalid-credentials'
+    });
+
+    await expect(
+      api.importGoogleMerchant({ googleMerchantId: '123', googleApiKey: 'bad' })
+    ).rejects.toEqual(expect.objectContaining({
+      code: 'google-merchant/invalid-credentials',
+      context: 'google-merchant:import',
+      message: 'Invalid credentials'
+    }));
+  });
+
+  test('wraps thrown errors from the Cloud Function', async () => {
+    importCatalogMock.mockRejectedValue(new Error('network failed'));
+
+    await expect(
+      api.importGoogleMerchant({ googleMerchantId: '123', googleApiKey: 'secret' })
+    ).rejects.toEqual(expect.objectContaining({
+      context: 'google-merchant:import',
+      message: 'network failed'
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- add a callable Cloud Function to simulate Google Merchant imports and persist catalog/import logs
- expose the new callable through the firebaseFunctions helper and update the client API wrapper to surface results
- cover success and error handling with focused unit tests that mock the Cloud Function response

## Testing
- npm test *(fails: Jest cannot parse existing ESM test suites in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68c938bada14832ab9fd0bd6e6d865a1