### PR TITLE
Add direction hook and centralize html language updates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,12 +21,16 @@ import { sellers as initialSellers, branches as initialBranches, paymentMethods 
 import api from '@/lib/api.js';
 import { TrendingUp, BookOpen, Users, DollarSign, Eye } from 'lucide-react';
 import { useLanguage, defaultLanguages } from '@/lib/languageContext.jsx';
+import { useTranslation } from 'react-i18next';
 import { jwtAuthManager, firebaseAuth } from '@/lib/jwtAuth.js';
 import { errorHandler } from '@/lib/errorHandler.js';
+import useDirection from '@/lib/useDirection.js';
 
 const App = () => {
   const [isAppLoading, setIsAppLoading] = useState(true);
   const [dashboardSection, setDashboardSection] = useState('overview');
+  const { i18n } = useTranslation();
+  useDirection(i18n.language);
   const { isAdmin: isAdminLoggedIn, isCustomer: isCustomerLoggedIn, currentUser, login } = useAuth();
   const { setLanguage, setLanguages, languages } = useLanguage();
   const { cart, setCart, addToCart, removeFromCart, updateQuantity } = useCart();

--- a/src/components/DashboardHeader.jsx
+++ b/src/components/DashboardHeader.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Search, Bell, Mail, Menu } from 'lucide-react';
 import { Input } from '@/components/ui/input.jsx';
@@ -6,14 +5,8 @@ import { Input } from '@/components/ui/input.jsx';
 const DashboardHeader = ({ sidebarOpen, setSidebarOpen }) => {
   const { i18n, t } = useTranslation();
 
-  // تغيير اتجاه الصفحة عند تغيير اللغة
-  React.useEffect(() => {
-    document.documentElement.dir = i18n.language === 'ar' ? 'rtl' : 'ltr';
-  }, [i18n.language]);
-
   const handleChangeLang = (lang) => {
     i18n.changeLanguage(lang);
-    document.documentElement.dir = lang === 'ar' ? 'rtl' : 'ltr';
   };
 
   return (

--- a/src/lib/languageContext.jsx
+++ b/src/lib/languageContext.jsx
@@ -28,8 +28,6 @@ export const LanguageProvider = ({ children }) => {
 
   useEffect(() => {
     localStorage.setItem('language', language.code);
-    document.documentElement.lang = language.code;
-    document.documentElement.dir = language.code === 'ar' ? 'rtl' : 'ltr';
   }, [language]);
 
   useEffect(() => {

--- a/src/lib/useDirection.js
+++ b/src/lib/useDirection.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+const RTL_LANGUAGES = new Set(['ar', 'he', 'fa', 'ur']);
+
+const resolveDirection = (language) => (RTL_LANGUAGES.has(language) ? 'rtl' : 'ltr');
+
+export function useDirection(language) {
+  useEffect(() => {
+    if (!language || typeof document === 'undefined') {
+      return;
+    }
+
+    const direction = resolveDirection(language);
+    document.documentElement.dir = direction;
+    document.documentElement.lang = language;
+  }, [language]);
+}
+
+export default useDirection;


### PR DESCRIPTION
## Summary
- add a reusable `useDirection` hook that synchronizes the document language and direction with the active locale
- invoke the hook in `App` so the root document updates from the current i18next language and stop duplicating the effect inside the language context
- remove the per-component direction management from `DashboardHeader` to rely on the shared hook

## Testing
- npm run build *(fails: Rollup failed to resolve import "i18next-http-backend" from src/lib/i18n.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c94abdd6e0832a93c687899f41f00f