### PR TITLE
Improve layout direction handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,7 @@ const App = () => {
   const [isAppLoading, setIsAppLoading] = useState(true);
   const [dashboardSection, setDashboardSection] = useState('overview');
   const { i18n } = useTranslation();
-  useDirection(i18n.language);
+  useDirection(i18n);
   const { isAdmin: isAdminLoggedIn, isCustomer: isCustomerLoggedIn, currentUser, login } = useAuth();
   const { setLanguage, setLanguages, languages } = useLanguage();
   const { cart, setCart, addToCart, removeFromCart, updateQuantity } = useCart();
@@ -488,7 +488,7 @@ const App = () => {
     <ErrorBoundary>
       <Router>
         <ScrollToTop />
-        <div className="font-sans" dir="rtl">
+        <div className="font-sans" dir={i18n.dir()}>
           <AnimatePresence mode="wait">
             <Suspense fallback={<div>Loading...</div>}>
               <Routes>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -51,7 +51,7 @@ const Header = ({ handleFeatureClick, books = [], categories = [], siteSettings 
   const { language, setLanguage, languages } = useLanguage();
   const { cart } = useCart();
   const { isCustomer: isCustomerLoggedIn } = useAuth();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
 
   const [hideTopRow, setHideTopRow] = useState(false);
@@ -166,7 +166,7 @@ const Header = ({ handleFeatureClick, books = [], categories = [], siteSettings 
               <span>{t('my_account')}</span>
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent dir="rtl" align="end" className="bg-white shadow-lg rounded-md border border-gray-200 text-gray-800 min-w-[180px]">
+          <DropdownMenuContent dir={i18n.dir()} align="end" className="bg-white shadow-lg rounded-md border border-gray-200 text-gray-800 min-w-[180px]">
             <DropdownMenuItem asChild className="px-4 py-3 hover:bg-blue-50 transition-colors duration-150">
               <Link to="/profile?tab=wishlist" className="flex items-center">
                 <Bookmark className="w-4 h-4 ml-2 rtl:mr-2 rtl:ml-0" />
@@ -490,7 +490,7 @@ const Header = ({ handleFeatureClick, books = [], categories = [], siteSettings 
               exit={{ opacity: 0, y: -20 }}
               transition={{ duration: 0.3, ease: "easeOut" }}
               className="fixed top-0 left-0 right-0 bg-white shadow-2xl z-50 md:hidden p-4"
-              dir="rtl"
+              dir={i18n.dir()}
             >
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-lg font-bold text-gray-800">{t('search_title')}</h2>
@@ -631,7 +631,7 @@ const Header = ({ handleFeatureClick, books = [], categories = [], siteSettings 
               exit={{ opacity: 0, x: '100%' }}
               transition={{ duration: 0.3, ease: "easeOut" }}
               className="fixed top-0 right-0 h-full w-80 max-w-[85vw] bg-white shadow-2xl z-50 md:hidden overflow-y-auto"
-              dir="rtl"
+              dir={i18n.dir()}
             >
               <div className="p-6">
                 {/* Header */}

--- a/src/components/InvoiceGenerator.jsx
+++ b/src/components/InvoiceGenerator.jsx
@@ -34,7 +34,7 @@ const InvoiceGenerator = ({ order, onPrint, onDownload, onShare }) => {
   if (!order) return null;
 
   return (
-    <div className="bg-white p-8 max-w-4xl mx-auto" dir="rtl">
+    <div className="bg-white p-8 max-w-4xl mx-auto">
       {/* Invoice Header */}
       <div className="border-b pb-6 mb-6">
         <div className="flex justify-between items-start">

--- a/src/lib/useDirection.js
+++ b/src/lib/useDirection.js
@@ -2,18 +2,65 @@ import { useEffect } from 'react';
 
 const RTL_LANGUAGES = new Set(['ar', 'he', 'fa', 'ur']);
 
-const resolveDirection = (language) => (RTL_LANGUAGES.has(language) ? 'rtl' : 'ltr');
+const resolveDirection = (language) => {
+  if (!language) {
+    return 'ltr';
+  }
 
-export function useDirection(language) {
+  const normalized = language.split('-')[0];
+  return RTL_LANGUAGES.has(normalized) ? 'rtl' : 'ltr';
+};
+
+export function useDirection(i18nOrLanguage) {
+  const language =
+    typeof i18nOrLanguage === 'object' && i18nOrLanguage !== null
+      ? i18nOrLanguage.language || i18nOrLanguage.resolvedLanguage
+      : i18nOrLanguage;
+
   useEffect(() => {
-    if (!language || typeof document === 'undefined') {
-      return;
+    if (!i18nOrLanguage || typeof document === 'undefined') {
+      return undefined;
     }
 
-    const direction = resolveDirection(language);
-    document.documentElement.dir = direction;
-    document.documentElement.lang = language;
-  }, [language]);
+    const isI18nInstance =
+      typeof i18nOrLanguage === 'object' &&
+      i18nOrLanguage !== null &&
+      (typeof i18nOrLanguage.dir === 'function' || typeof i18nOrLanguage.on === 'function');
+
+    const getDirection = (lng) => {
+      if (isI18nInstance && typeof i18nOrLanguage.dir === 'function') {
+        return i18nOrLanguage.dir(lng);
+      }
+
+      return resolveDirection(lng);
+    };
+
+    const applyDirection = (lng) => {
+      const nextLanguage = lng || language || 'en';
+      const direction = getDirection(nextLanguage) || 'ltr';
+
+      document.documentElement.dir = direction;
+      document.documentElement.lang = nextLanguage;
+    };
+
+    applyDirection(language);
+
+    if (isI18nInstance && typeof i18nOrLanguage.on === 'function') {
+      const handleLanguageChanged = (lng) => {
+        applyDirection(lng);
+      };
+
+      i18nOrLanguage.on('languageChanged', handleLanguageChanged);
+
+      return () => {
+        if (typeof i18nOrLanguage.off === 'function') {
+          i18nOrLanguage.off('languageChanged', handleLanguageChanged);
+        }
+      };
+    }
+
+    return undefined;
+  }, [i18nOrLanguage, language]);
 }
 
 export default useDirection;

--- a/src/pages/AudiobookPage.jsx
+++ b/src/pages/AudiobookPage.jsx
@@ -205,7 +205,7 @@ const AudiobookPage = () => {
                 </motion.div>
               ))}
             </div>
-<div className="md:w-1/2 text-right" dir="rtl">
+            <div className="md:w-1/2 text-right">
               <h2 className="text-2xl sm:text-3xl font-bold text-gray-800 mb-3">{t('curated_stories_heading')}</h2>
               <p className="text-gray-600 text-sm sm:text-base mb-6">
                 {t('curated_stories_description')}
@@ -236,7 +236,7 @@ const AudiobookPage = () => {
               ))}
             </div>
 
-<div className="md:w-1/2 text-right" dir="rtl">
+            <div className="md:w-1/2 text-right">
               <h2 className="text-2xl sm:text-3xl font-bold text-gray-800 mb-3">{t('anytime_anywhere_heading')}</h2>
               <p className="text-gray-600 text-sm sm:text-base mb-6">
                 {t('anytime_anywhere_description')}


### PR DESCRIPTION
## Summary
- use the i18next instance when applying the layout direction so the root container reflects the active locale
- enhance the direction hook to listen for language changes and drive document.dir/document.lang updates
- swap hardcoded rtl flags in shared UI (header overlays, invoice, audiobook sections) for i18n-aware or inherited direction

## Testing
- npm test -- --watch=false *(fails: repository tests expect CommonJS-compatible configuration and abort with existing syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c96b4ebb7c832a9a9258c708eaf612