### PR TITLE
Lazy load homepage sections with skeleton fallbacks

### DIFF
--- a/src/components/AuthorsSkeleton.jsx
+++ b/src/components/AuthorsSkeleton.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+const AuthorsSkeleton = () => {
+  const authorPlaceholders = Array.from({ length: 10 });
+
+  return (
+    <section className="py-8 sm:py-10 bg-slate-100">
+      <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between mb-5 sm:mb-6 w-full">
+          <div className="h-6 sm:h-7 bg-slate-200 rounded animate-pulse w-40" />
+          <div className="h-8 w-24 bg-slate-200 rounded-md animate-pulse" />
+        </div>
+
+        <div className="block sm:hidden">
+          <div className="flex gap-x-4 overflow-x-auto pb-2">
+            {authorPlaceholders.map((_, index) => (
+              <div
+                key={`author-mobile-${index}`}
+                className="flex-shrink-0 text-center"
+              >
+                <div className="w-16 h-16 mx-auto mb-2 rounded-full bg-slate-200 animate-pulse" />
+                <div className="h-3 bg-slate-200 rounded animate-pulse w-16 mx-auto" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="hidden sm:grid grid-cols-6 md:grid-cols-8 lg:grid-cols-10 gap-x-3 gap-y-4">
+          {authorPlaceholders.map((_, index) => (
+            <div key={`author-desktop-${index}`} className="text-center">
+              <div className="w-16 h-16 mx-auto mb-2 rounded-full bg-slate-200 animate-pulse" />
+              <div className="h-3 bg-slate-200 rounded animate-pulse w-20 mx-auto" />
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8 sm:mt-10 grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
+          <div className="h-40 sm:h-48 bg-slate-200 rounded-lg animate-pulse" />
+          <div className="h-40 sm:h-48 bg-slate-200 rounded-lg animate-pulse" />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default AuthorsSkeleton;

--- a/src/components/BookBestsellerSkeleton.jsx
+++ b/src/components/BookBestsellerSkeleton.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+const BookBestsellerSkeleton = () => {
+  const skeletonItems = Array.from({ length: 6 });
+
+  const renderCard = (key) => (
+    <div
+      key={key}
+      className="flex-shrink-0 w-40 sm:w-auto border border-slate-200 rounded-lg p-3 sm:p-4 bg-white"
+    >
+      <div className="mb-3 sm:mb-4 rounded-md bg-slate-200 animate-pulse aspect-[3/4]" />
+      <div className="space-y-2">
+        <div className="h-3 bg-slate-200 rounded animate-pulse w-4/5" />
+        <div className="h-3 bg-slate-200 rounded animate-pulse w-3/5" />
+        <div className="h-3 bg-slate-200 rounded animate-pulse w-2/5" />
+        <div className="h-4 bg-slate-200 rounded animate-pulse w-1/2" />
+      </div>
+      <div className="mt-3 h-8 bg-slate-200 rounded-md animate-pulse" />
+    </div>
+  );
+
+  return (
+    <section className="py-8 sm:py-10">
+      <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 bg-white p-4 rounded-[18px]">
+        <div className="flex flex-col sm:flex-row items-center justify-between mb-5 sm:mb-6 w-full">
+          <div className="flex items-center space-x-2 sm:space-x-2.5 rtl:space-x-reverse mb-3 sm:mb-0 w-full sm:w-auto">
+            <div className="h-7 w-7 bg-slate-200 rounded-full animate-pulse" />
+            <div className="h-5 sm:h-6 bg-slate-200 rounded animate-pulse w-32 sm:w-44" />
+          </div>
+          <div className="hidden sm:block h-8 w-24 bg-slate-200 rounded-md animate-pulse" />
+        </div>
+
+        <div className="block sm:hidden">
+          <div className="flex gap-x-4 overflow-x-auto pb-2">
+            {skeletonItems.map((_, index) => renderCard(`bestseller-mobile-${index}`))}
+          </div>
+        </div>
+
+        <div className="hidden sm:grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+          {skeletonItems.map((_, index) => (
+            <div
+              key={`bestseller-desktop-${index}`}
+              className="border border-slate-200 rounded-lg p-4 bg-white"
+            >
+              <div className="mb-4 rounded-md bg-slate-200 animate-pulse aspect-[3/4]" />
+              <div className="space-y-2">
+                <div className="h-3 bg-slate-200 rounded animate-pulse w-4/5" />
+                <div className="h-3 bg-slate-200 rounded animate-pulse w-3/5" />
+                <div className="h-3 bg-slate-200 rounded animate-pulse w-1/2" />
+                <div className="h-4 bg-slate-200 rounded animate-pulse w-2/5" />
+              </div>
+              <div className="mt-4 h-9 bg-slate-200 rounded-md animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default BookBestsellerSkeleton;

--- a/src/components/FeaturesSkeleton.jsx
+++ b/src/components/FeaturesSkeleton.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+const FeaturesSkeleton = () => {
+  const featurePlaceholders = Array.from({ length: 4 });
+  const bannerPlaceholders = Array.from({ length: 3 });
+
+  return (
+    <section className="py-8 sm:py-10 bg-slate-100">
+      <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
+          {featurePlaceholders.map((_, index) => (
+            <div
+              key={`feature-${index}`}
+              className="flex items-center p-3 sm:p-4 bg-white rounded-lg shadow-sm space-x-3 rtl:space-x-reverse"
+            >
+              <div className="w-10 h-10 sm:w-12 sm:h-12 bg-slate-200 rounded-full animate-pulse" />
+              <div className="flex-1 space-y-2">
+                <div className="h-4 bg-slate-200 rounded animate-pulse w-3/4" />
+                <div className="h-3 bg-slate-200 rounded animate-pulse w-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-10 sm:mt-12 text-center space-y-4">
+          <div className="grid grid-cols-3 gap-2 sm:gap-4">
+            {bannerPlaceholders.map((_, index) => (
+              <div
+                key={`banner-${index}`}
+                className="h-24 sm:h-32 bg-slate-200 rounded-md animate-pulse"
+              />
+            ))}
+          </div>
+          <div className="h-5 sm:h-6 bg-slate-200 rounded animate-pulse w-2/3 mx-auto" />
+          <div className="h-4 sm:h-5 bg-slate-200 rounded animate-pulse w-11/12 sm:w-2/3 mx-auto" />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default FeaturesSkeleton;

--- a/src/components/FlashSaleSkeleton.jsx
+++ b/src/components/FlashSaleSkeleton.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+const FlashSaleSkeleton = () => {
+  const skeletonItems = Array.from({ length: 6 });
+
+  const renderCard = (key) => (
+    <div
+      key={key}
+      className="flex-shrink-0 w-40 sm:w-auto border border-slate-200 rounded-lg p-2 sm:p-3 bg-white"
+    >
+      <div className="mb-2 sm:mb-3 rounded-md bg-slate-200 animate-pulse aspect-[3/4]" />
+      <div className="space-y-1">
+        <div className="h-3 bg-slate-200 rounded animate-pulse w-3/4" />
+        <div className="h-3 bg-slate-200 rounded animate-pulse w-1/2" />
+        <div className="h-4 bg-slate-200 rounded animate-pulse w-1/3" />
+      </div>
+    </div>
+  );
+
+  return (
+    <section className="py-8 sm:py-10">
+      <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 bg-white p-4 rounded-[18px]">
+        <div className="flex flex-col sm:flex-row items-center justify-between mb-5 sm:mb-6 w-full">
+          <div className="flex items-center space-x-2 sm:space-x-2.5 rtl:space-x-reverse mb-3 sm:mb-0 w-full sm:w-auto">
+            <div className="h-7 w-7 bg-slate-200 rounded-full animate-pulse" />
+            <div className="h-5 sm:h-6 bg-slate-200 rounded animate-pulse w-32 sm:w-40" />
+          </div>
+          <div className="hidden sm:block h-8 w-24 bg-slate-200 rounded-md animate-pulse" />
+        </div>
+
+        <div className="block sm:hidden">
+          <div className="flex gap-x-4 overflow-x-auto pb-2">
+            {skeletonItems.map((_, index) => renderCard(`flash-mobile-${index}`))}
+          </div>
+        </div>
+
+        <div className="hidden sm:grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+          {skeletonItems.map((_, index) => (
+            <div
+              key={`flash-desktop-${index}`}
+              className="border border-slate-200 rounded-lg p-3 bg-white"
+            >
+              <div className="mb-3 rounded-md bg-slate-200 animate-pulse aspect-[3/4]" />
+              <div className="space-y-2">
+                <div className="h-3 bg-slate-200 rounded animate-pulse w-5/6" />
+                <div className="h-3 bg-slate-200 rounded animate-pulse w-2/3" />
+                <div className="h-4 bg-slate-200 rounded animate-pulse w-1/2" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default FlashSaleSkeleton;

--- a/src/components/RecentSearchSkeleton.jsx
+++ b/src/components/RecentSearchSkeleton.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+const RecentSearchSkeleton = () => {
+  const skeletonItems = Array.from({ length: 6 });
+
+  const renderCard = (key) => (
+    <div
+      key={key}
+      className="flex-shrink-0 w-40 sm:w-auto border border-slate-200 rounded-lg p-2 sm:p-3 bg-white"
+    >
+      <div className="mb-2 sm:mb-3 rounded-md bg-slate-200 animate-pulse aspect-[3/4]" />
+      <div className="space-y-1.5">
+        <div className="h-3 bg-slate-200 rounded animate-pulse w-4/5" />
+        <div className="h-3 bg-slate-200 rounded animate-pulse w-2/3" />
+        <div className="h-4 bg-slate-200 rounded animate-pulse w-1/2" />
+      </div>
+    </div>
+  );
+
+  return (
+    <section className="py-8 sm:py-10 bg-slate-100">
+      <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col sm:flex-row items-center justify-between mb-5 sm:mb-6 w-full">
+          <div className="flex items-center space-x-2 sm:space-x-2.5 rtl:space-x-reverse mb-3 sm:mb-0 w-full sm:w-auto">
+            <div className="h-7 w-7 bg-slate-200 rounded-full animate-pulse" />
+            <div className="h-5 sm:h-6 bg-slate-200 rounded animate-pulse w-32 sm:w-40" />
+          </div>
+          <div className="hidden sm:block h-8 w-24 bg-slate-200 rounded-md animate-pulse" />
+        </div>
+
+        <div className="block sm:hidden">
+          <div className="flex gap-x-4 overflow-x-auto pb-2">
+            {skeletonItems.map((_, index) => renderCard(`recent-mobile-${index}`))}
+          </div>
+        </div>
+
+        <div className="hidden sm:grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+          {skeletonItems.map((_, index) => (
+            <div
+              key={`recent-desktop-${index}`}
+              className="border border-slate-200 rounded-lg p-3 bg-white"
+            >
+              <div className="mb-3 rounded-md bg-slate-200 animate-pulse aspect-[3/4]" />
+              <div className="space-y-2">
+                <div className="h-3 bg-slate-200 rounded animate-pulse w-4/5" />
+                <div className="h-3 bg-slate-200 rounded animate-pulse w-2/3" />
+                <div className="h-4 bg-slate-200 rounded animate-pulse w-1/2" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default RecentSearchSkeleton;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -2,12 +2,18 @@
 import React from 'react';
 import HeroSection from '@/components/HeroSection.jsx';
 import CategoriesSection from '@/components/CategoriesSection.jsx';
-import FlashSaleSection from '@/components/FlashSaleSection.jsx';
-import AuthorsSection from '@/components/AuthorsSection.jsx';
-import RecentSearchSection from '@/components/RecentSearchSection.jsx';
-import BookBestsellerSection from '@/components/BookBestsellerSection.jsx';
-import FeaturesSection from '@/components/FeaturesSection.jsx';
+import FlashSaleSkeleton from '@/components/FlashSaleSkeleton.jsx';
+import AuthorsSkeleton from '@/components/AuthorsSkeleton.jsx';
+import RecentSearchSkeleton from '@/components/RecentSearchSkeleton.jsx';
+import BookBestsellerSkeleton from '@/components/BookBestsellerSkeleton.jsx';
+import FeaturesSkeleton from '@/components/FeaturesSkeleton.jsx';
 import { TrendingUp } from 'lucide-react';
+
+const FlashSaleSection = React.lazy(() => import('@/components/FlashSaleSection.jsx'));
+const AuthorsSection = React.lazy(() => import('@/components/AuthorsSection.jsx'));
+const RecentSearchSection = React.lazy(() => import('@/components/RecentSearchSection.jsx'));
+const BookBestsellerSection = React.lazy(() => import('@/components/BookBestsellerSection.jsx'));
+const FeaturesSection = React.lazy(() => import('@/components/FeaturesSection.jsx'));
 
 const HomePage = ({
   books,
@@ -35,41 +41,53 @@ const HomePage = ({
     <>
       <HeroSection slides={heroSlides} />
       <CategoriesSection categories={displayedCategories} />
-      <FlashSaleSection
-        books={books}
-        handleAddToCart={handleAddToCart}
-        handleToggleWishlist={handleToggleWishlist}
-        wishlist={wishlist}
-      />
-      <AuthorsSection 
-        authors={authors} 
-      />
-      <RecentSearchSection
-        books={recentSearchBooks}
-        handleAddToCart={handleAddToCart}
-        handleToggleWishlist={handleToggleWishlist}
-        wishlist={wishlist}
-      />
-      <BookBestsellerSection
-        books={bestsellerBooks}
-        handleAddToCart={handleAddToCart}
-        handleToggleWishlist={handleToggleWishlist}
-        wishlist={wishlist}
-        title="الكتب الصوتية الأكثر مبيعاً"
-        icon={TrendingUp}
-        squareImages
-      />
-      <BookBestsellerSection
-        books={bestsellerBooks.slice(0,3).concat(bestsellerBooks.slice(0,3))}
-        handleAddToCart={handleAddToCart}
-        handleToggleWishlist={handleToggleWishlist}
-        wishlist={wishlist}
-        title="الكتب الأكثر مبيعاً"
-        icon={TrendingUp}
-        bgColor="bg-slate-100"
-        likeCardStyle
-      />
-      <FeaturesSection features={features} banners={banners} handleFeatureClick={handleFeatureClick} />
+      <React.Suspense fallback={<FlashSaleSkeleton />}>
+        <FlashSaleSection
+          books={books}
+          handleAddToCart={handleAddToCart}
+          handleToggleWishlist={handleToggleWishlist}
+          wishlist={wishlist}
+        />
+      </React.Suspense>
+      <React.Suspense fallback={<AuthorsSkeleton />}>
+        <AuthorsSection
+          authors={authors}
+        />
+      </React.Suspense>
+      <React.Suspense fallback={<RecentSearchSkeleton />}>
+        <RecentSearchSection
+          books={recentSearchBooks}
+          handleAddToCart={handleAddToCart}
+          handleToggleWishlist={handleToggleWishlist}
+          wishlist={wishlist}
+        />
+      </React.Suspense>
+      <React.Suspense fallback={<BookBestsellerSkeleton />}>
+        <BookBestsellerSection
+          books={bestsellerBooks}
+          handleAddToCart={handleAddToCart}
+          handleToggleWishlist={handleToggleWishlist}
+          wishlist={wishlist}
+          title="الكتب الصوتية الأكثر مبيعاً"
+          icon={TrendingUp}
+          squareImages
+        />
+      </React.Suspense>
+      <React.Suspense fallback={<BookBestsellerSkeleton />}>
+        <BookBestsellerSection
+          books={bestsellerBooks.slice(0,3).concat(bestsellerBooks.slice(0,3))}
+          handleAddToCart={handleAddToCart}
+          handleToggleWishlist={handleToggleWishlist}
+          wishlist={wishlist}
+          title="الكتب الأكثر مبيعاً"
+          icon={TrendingUp}
+          bgColor="bg-slate-100"
+          likeCardStyle
+        />
+      </React.Suspense>
+      <React.Suspense fallback={<FeaturesSkeleton />}>
+        <FeaturesSection features={features} banners={banners} handleFeatureClick={handleFeatureClick} />
+      </React.Suspense>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- lazy-load the flash sale, author, recent search, bestseller, and features blocks on the home page with Suspense fallbacks
- add skeleton placeholder components for each lazily loaded section to preserve layout while bundles load

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c986c6c110832aad2844ba139a9675