### PR TITLE
Add shared checkbox component and use on cart page

### DIFF
--- a/src/components/ui/checkbox.jsx
+++ b/src/components/ui/checkbox.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+
+import { cn } from "@/lib/utils.js";
+
+const Checkbox = React.forwardRef(
+  ({ className, onChange, onCheckedChange, ...props }, ref) => {
+    const handleCheckedChange = React.useCallback(
+      (checked) => {
+        if (typeof onCheckedChange === "function") {
+          onCheckedChange(checked);
+        }
+
+        if (typeof onChange === "function") {
+          if (typeof checked === "boolean") {
+            onChange(checked);
+          } else {
+            onChange(checked === "indeterminate");
+          }
+        }
+      },
+      [onChange, onCheckedChange],
+    );
+
+    return (
+      <CheckboxPrimitive.Root
+        ref={ref}
+        className={cn(
+          "peer h-5 w-5 shrink-0 rounded border border-input bg-background text-primary-foreground ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary",
+          className,
+        )}
+        onCheckedChange={handleCheckedChange}
+        {...props}
+      >
+        <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+          <Check className="h-3.5 w-3.5" />
+        </CheckboxPrimitive.Indicator>
+      </CheckboxPrimitive.Root>
+    );
+  },
+);
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/src/pages/CartPage.jsx
+++ b/src/pages/CartPage.jsx
@@ -6,12 +6,20 @@ import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button.jsx';
 import { Trash2, Plus, Minus, ShoppingCart, CreditCard, Heart, ChevronLeft, Tag } from 'lucide-react';
 import { Input } from '@/components/ui/input.jsx';
-// import { Checkbox } from '@/components/ui/checkbox.jsx'; // Assuming you have a Checkbox component from shadcn/ui
+import { Checkbox } from '@/components/ui/checkbox.jsx';
 
 const CartPage = ({ cart, handleRemoveFromCart, handleUpdateQuantity }) => {
   const { currency } = useCurrency();
   const totalPrice = cart.reduce((sum, item) => sum + getPriceForCurrency(item, currency.code) * item.quantity, 0);
   const totalQuantity = cart.reduce((sum, item) => sum + item.quantity, 0);
+
+  const [isSelectAllChecked, setIsSelectAllChecked] = React.useState(false);
+
+  React.useEffect(() => {
+    if (cart.length === 0) {
+      setIsSelectAllChecked(false);
+    }
+  }, [cart.length]);
 
   // Example logic for discounts based on total price
   const discountThreshold = 105.00; // Example: Discount if total is over 105 AED
@@ -183,8 +191,11 @@ const CartPage = ({ cart, handleRemoveFromCart, handleUpdateQuantity }) => {
             </div>
 
             <div className="flex items-center mb-5 text-sm text-gray-600 space-x-2 rtl:space-x-reverse">
-              {/* <Checkbox id="terms" /> */} {/* Removed due to missing component */}
-              <input type="checkbox" id="terms" className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500" /> {/* Basic checkbox added */}
+              <Checkbox
+                id="terms"
+                checked={isSelectAllChecked}
+                onChange={(checked) => setIsSelectAllChecked(Boolean(checked))}
+              />
               <label htmlFor="terms" className="cursor-pointer">
                 أختر الكل ({totalQuantity} منتجات)
               </label>


### PR DESCRIPTION
## Summary
- add a reusable checkbox component built on top of Radix primitives in `src/components/ui`
- wire the cart page's select-all control to the new checkbox and manage its checked state
- reset the select-all state when the cart empties for consistent behaviour on all devices

## Testing
- `npm test -- --watch=false` *(fails: existing Jest configuration cannot process several test suites that use ESM and scoped variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c98d3c230c832a88d1a85f61978f09