### PR TITLE
Add remote persistence for cart and favorites

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -13,6 +13,153 @@ import unifiedPaymentApi from './api/unifiedPaymentApi.js';
 import logger from './logger.js';
 import * as encryptedCache from './encryptedCache.js';
 import homeApi from './firebase/homeApi.js';
+import { jwtAuthManager } from './jwtAuth.js';
+
+const API_BASE_URL =
+  (typeof import.meta !== 'undefined' &&
+    import.meta.env &&
+    import.meta.env.VITE_API_BASE_URL) ||
+  '';
+
+const ensureArrayResponse = (payload, key) => {
+  if (!payload) {
+    return [];
+  }
+
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (key && Array.isArray(payload[key])) {
+    return payload[key];
+  }
+
+  if (Array.isArray(payload.items)) {
+    return payload.items;
+  }
+
+  if (Array.isArray(payload.data)) {
+    return payload.data;
+  }
+
+  return [];
+};
+
+async function requestUserData(userId, resource, { method = 'GET', body } = {}) {
+  const context = `user-data:${resource}:${userId || 'anonymous'}`;
+
+  try {
+    if (!userId) {
+      throw errorHandler.createError(
+        errorHandler.errorTypes.VALIDATION,
+        'validation/user-id-missing',
+        'معرف المستخدم مطلوب لمزامنة البيانات',
+        context
+      );
+    }
+
+    if (!API_BASE_URL) {
+      throw errorHandler.createError(
+        errorHandler.errorTypes.UNKNOWN,
+        'config/api-base-url-missing',
+        'لم يتم تكوين عنوان الخادم لواجهات البرمجة',
+        context
+      );
+    }
+
+    const headers = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json'
+    };
+
+    if (jwtAuthManager && typeof jwtAuthManager.getIdToken === 'function') {
+      const token = await jwtAuthManager.getIdToken();
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+    }
+
+    const response = await fetch(`${API_BASE_URL}/users/${userId}/${resource}`, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined
+    });
+
+    if (!response.ok) {
+      const message = await response.text().catch(() => '');
+      const errorMessage = message || `فشل في معالجة طلب ${resource}`;
+      throw errorHandler.createError(
+        errorHandler.errorTypes.NETWORK,
+        `api/${resource}-${response.status}`,
+        errorMessage,
+        context
+      );
+    }
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      return await response.json();
+    }
+
+    return null;
+  } catch (error) {
+    throw errorHandler.handleError(error, context);
+  }
+}
+
+const userDataApi = {
+  getFavorites: async (userId) => {
+    try {
+      const response = await requestUserData(userId, 'favorites');
+      return ensureArrayResponse(response, 'favorites');
+    } catch (error) {
+      throw errorHandler.handleError(error, `user-data:get-favorites:${userId}`);
+    }
+  },
+
+  saveFavorites: async (userId, favorites = []) => {
+    try {
+      const response = await requestUserData(userId, 'favorites', {
+        method: 'PUT',
+        body: {
+          favorites,
+          updatedAt: new Date().toISOString()
+        }
+      });
+      return response == null ? favorites : ensureArrayResponse(response, 'favorites');
+    } catch (error) {
+      throw errorHandler.handleError(error, `user-data:save-favorites:${userId}`);
+    }
+  },
+
+  getCart: async (userId) => {
+    try {
+      const response = await requestUserData(userId, 'cart');
+      return ensureArrayResponse(response, 'items');
+    } catch (error) {
+      throw errorHandler.handleError(error, `user-data:get-cart:${userId}`);
+    }
+  },
+
+  saveCart: async (userId, cartItems = []) => {
+    try {
+      const response = await requestUserData(userId, 'cart', {
+        method: 'PUT',
+        body: {
+          items: cartItems,
+          updatedAt: new Date().toISOString()
+        }
+      });
+      return response == null ? cartItems : ensureArrayResponse(response, 'items');
+    } catch (error) {
+      throw errorHandler.handleError(error, `user-data:save-cart:${userId}`);
+    }
+  }
+};
 
 // Firebase API هو الآن الخيار الوحيد مع Functions
 const api = {
@@ -825,6 +972,7 @@ const api = {
       throw errorHandler.handleError(error, `api:get-customer-data:${customerId}`);
     }
   },
+  userData: userDataApi,
   cart: CartService
 };
 

--- a/src/lib/cartContext.jsx
+++ b/src/lib/cartContext.jsx
@@ -1,23 +1,294 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import api from './api.js';
+import { useAuth } from './authContext.jsx';
+import logger from './logger.js';
 
 const CartContext = createContext(null);
 
+const LOCAL_STORAGE_KEY = 'molhemon:cart';
+const isBrowser = typeof window !== 'undefined';
+
+const getCartItemKey = (item, fallbackIndex = 0) => {
+  if (!item || typeof item !== 'object') {
+    return `${fallbackIndex}`;
+  }
+
+  const key =
+    item.id ??
+    item.productId ??
+    item.bookId ??
+    item.variantId ??
+    item.sku ??
+    item.slug;
+
+  if (key === undefined || key === null) {
+    try {
+      return JSON.stringify(item);
+    } catch (error) {
+      return `${fallbackIndex}`;
+    }
+  }
+
+  return String(key);
+};
+
+const ensureCartItemShape = (item) => {
+  if (!item || typeof item !== 'object') {
+    return null;
+  }
+
+  const quantity = Number.isFinite(item.quantity) ? Math.max(1, item.quantity) : 1;
+
+  return {
+    ...item,
+    quantity
+  };
+};
+
+const normalizeCartItems = (items = []) =>
+  (Array.isArray(items) ? items : [])
+    .map(ensureCartItemShape)
+    .filter(Boolean)
+    .sort((a, b) => {
+      const keyA = getCartItemKey(a);
+      const keyB = getCartItemKey(b);
+      return keyA.localeCompare(keyB);
+    });
+
+const cartsAreEqual = (first = [], second = []) => {
+  const normalizedFirst = normalizeCartItems(first);
+  const normalizedSecond = normalizeCartItems(second);
+
+  if (normalizedFirst.length !== normalizedSecond.length) {
+    return false;
+  }
+
+  return normalizedFirst.every((item, index) => {
+    const other = normalizedSecond[index];
+    return JSON.stringify(item) === JSON.stringify(other);
+  });
+};
+
+const readLocalCart = () => {
+  if (!isBrowser) {
+    return [];
+  }
+
+  try {
+    const stored = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+
+    const parsed = JSON.parse(stored);
+    return normalizeCartItems(parsed);
+  } catch (error) {
+    logger.warn('Failed to read cart from localStorage, falling back to empty cart', error);
+    return [];
+  }
+};
+
+const writeLocalCart = (items) => {
+  if (!isBrowser) {
+    return;
+  }
+
+  try {
+    const safeItems = normalizeCartItems(items);
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(safeItems));
+  } catch (error) {
+    logger.warn('Failed to persist cart to localStorage', error);
+  }
+};
+
+const mergeCartItems = (remote = [], local = []) => {
+  const merged = new Map();
+
+  normalizeCartItems(remote).forEach((item, index) => {
+    const key = getCartItemKey(item, index);
+    merged.set(key, item);
+  });
+
+  normalizeCartItems(local).forEach((item, index) => {
+    const key = getCartItemKey(item, index + merged.size);
+    if (merged.has(key)) {
+      const existing = merged.get(key);
+      const quantity = (existing.quantity ?? 1) + (item.quantity ?? 1);
+      merged.set(key, { ...existing, quantity });
+    } else {
+      merged.set(key, item);
+    }
+  });
+
+  return Array.from(merged.values());
+};
+
 export const CartProvider = ({ children }) => {
-  const [cart, setCart] = useState([]);
+  const { currentUser } = useAuth();
+  const [cart, setCartState] = useState(() => readLocalCart());
 
-  const addToCart = (item) => {
-    setCart(prev => [...prev, item]);
-  };
+  useEffect(() => {
+    let isMounted = true;
 
-  const removeFromCart = (id) => {
-    setCart(prev => prev.filter(item => item.id !== id));
-  };
+    const initializeCart = async () => {
+      const localCart = readLocalCart();
 
-  const updateQuantity = (id, quantity) => {
-    setCart(prev => prev.map(item => item.id === id ? { ...item, quantity } : item));
-  };
+      if (!currentUser) {
+        if (isMounted) {
+          setCartState(localCart);
+        }
+        return;
+      }
 
-  const clearCart = () => setCart([]);
+      try {
+        const remoteCart = await api.userData.getCart(currentUser.uid);
+        const remoteItems = Array.isArray(remoteCart) ? remoteCart : [];
+        const mergedCart = mergeCartItems(remoteItems, localCart);
+
+        if (isMounted) {
+          setCartState(mergedCart);
+        }
+        writeLocalCart(mergedCart);
+
+        if (!cartsAreEqual(remoteItems, mergedCart)) {
+          try {
+            await api.userData.saveCart(currentUser.uid, mergedCart);
+          } catch (syncError) {
+            logger.error('Failed to synchronize cart with the server', syncError);
+          }
+        }
+      } catch (error) {
+        logger.warn('Unable to load remote cart, falling back to local storage', error);
+        if (isMounted) {
+          setCartState(localCart);
+        }
+      }
+    };
+
+    initializeCart();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [currentUser?.uid]);
+
+  const persistCart = useCallback(
+    (nextCart) => {
+      const safeCart = normalizeCartItems(nextCart);
+      writeLocalCart(safeCart);
+
+      if (currentUser) {
+        api.userData.saveCart(currentUser.uid, safeCart).catch((error) => {
+          logger.error('Failed to persist cart remotely', error);
+        });
+      }
+    },
+    [currentUser?.uid]
+  );
+
+  const applyCartUpdate = useCallback(
+    (updater) => {
+      setCartState((previousCart) => {
+        const result = typeof updater === 'function' ? updater(previousCart) : updater;
+        const normalizedResult = normalizeCartItems(result);
+
+        if (cartsAreEqual(previousCart, normalizedResult)) {
+          return previousCart;
+        }
+
+        persistCart(normalizedResult);
+        return normalizedResult;
+      });
+    },
+    [persistCart]
+  );
+
+  const setCart = useCallback(
+    (value) => {
+      applyCartUpdate(value);
+    },
+    [applyCartUpdate]
+  );
+
+  const addToCart = useCallback(
+    (item) => {
+      if (!item) {
+        return;
+      }
+
+      applyCartUpdate((previousCart) => {
+        const normalizedItem = ensureCartItemShape(item);
+        if (!normalizedItem) {
+          return previousCart;
+        }
+
+        const key = getCartItemKey(normalizedItem);
+        const index = previousCart.findIndex((cartItem) => getCartItemKey(cartItem) === key);
+
+        if (index !== -1) {
+          const updatedCart = [...previousCart];
+          const existingItem = updatedCart[index];
+          const quantity = (existingItem.quantity ?? 1) + (normalizedItem.quantity ?? 1);
+          updatedCart[index] = { ...existingItem, quantity };
+          return updatedCart;
+        }
+
+        return [...previousCart, normalizedItem];
+      });
+    },
+    [applyCartUpdate]
+  );
+
+  const removeFromCart = useCallback(
+    (identifier) => {
+      if (identifier === undefined || identifier === null) {
+        return;
+      }
+
+      const identifierString = String(identifier);
+
+      applyCartUpdate((previousCart) =>
+        previousCart.filter((item, index) => {
+          if (item?.id !== undefined && item?.id !== null) {
+            return String(item.id) !== identifierString;
+          }
+
+          const key = getCartItemKey(item, index);
+          return key !== identifierString;
+        })
+      );
+    },
+    [applyCartUpdate]
+  );
+
+  const updateQuantity = useCallback(
+    (identifier, quantity) => {
+      if (identifier === undefined || identifier === null) {
+        return;
+      }
+
+      const safeQuantity = Number.isFinite(quantity) ? Math.max(1, quantity) : 1;
+      const identifierString = String(identifier);
+
+      applyCartUpdate((previousCart) =>
+        previousCart.map((item, index) => {
+          const matchesId = item?.id !== undefined && item?.id !== null && String(item.id) === identifierString;
+          const matchesKey = getCartItemKey(item, index) === identifierString;
+
+          if (matchesId || matchesKey) {
+            return { ...item, quantity: safeQuantity };
+          }
+
+          return item;
+        })
+      );
+    },
+    [applyCartUpdate]
+  );
+
+  const clearCart = useCallback(() => {
+    applyCartUpdate([]);
+  }, [applyCartUpdate]);
 
   return (
     <CartContext.Provider value={{ cart, setCart, addToCart, removeFromCart, updateQuantity, clearCart }}>

--- a/src/lib/favoritesContext.jsx
+++ b/src/lib/favoritesContext.jsx
@@ -1,16 +1,210 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import api from './api.js';
+import { useAuth } from './authContext.jsx';
+import logger from './logger.js';
 
 const FavoritesContext = createContext(null);
 
-export const FavoritesProvider = ({ children }) => {
-  const [favorites, setFavorites] = useState([]);
+const LOCAL_STORAGE_KEY = 'molhemon:favorites';
+const isBrowser = typeof window !== 'undefined';
 
-  const toggleFavorite = (book) => {
-    setFavorites(prev => {
-      const exists = prev.find(item => item.id === book.id);
-      return exists ? prev.filter(item => item.id !== book.id) : [...prev, book];
+const getItemKey = (item, fallbackIndex = 0) => {
+  if (!item || typeof item !== 'object') {
+    return `${fallbackIndex}`;
+  }
+
+  const key =
+    item.id ??
+    item.bookId ??
+    item.slug ??
+    item.handle ??
+    item.productId ??
+    item.isbn;
+
+  if (key === undefined || key === null) {
+    try {
+      return JSON.stringify(item);
+    } catch (error) {
+      return `${fallbackIndex}`;
+    }
+  }
+
+  return String(key);
+};
+
+const readLocalFavorites = () => {
+  if (!isBrowser) {
+    return [];
+  }
+
+  try {
+    const stored = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    logger.warn('Failed to read favorites from localStorage, falling back to empty list', error);
+    return [];
+  }
+};
+
+const writeLocalFavorites = (items) => {
+  if (!isBrowser) {
+    return;
+  }
+
+  try {
+    const safeItems = Array.isArray(items) ? items : [];
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(safeItems));
+  } catch (error) {
+    logger.warn('Failed to persist favorites to localStorage', error);
+  }
+};
+
+const mergeFavorites = (remote = [], local = []) => {
+  const merged = new Map();
+
+  remote.forEach((item, index) => {
+    const key = getItemKey(item, index);
+    if (!merged.has(key)) {
+      merged.set(key, item);
+    }
+  });
+
+  local.forEach((item, index) => {
+    const key = getItemKey(item, index + merged.size);
+    if (!merged.has(key)) {
+      merged.set(key, item);
+    }
+  });
+
+  return Array.from(merged.values());
+};
+
+const normalizeFavorites = (items = []) =>
+  (Array.isArray(items) ? items : [])
+    .filter(Boolean)
+    .map((item) => ({ ...item }))
+    .sort((a, b) => {
+      const keyA = getItemKey(a);
+      const keyB = getItemKey(b);
+      return keyA.localeCompare(keyB);
     });
-  };
+
+const favoritesAreEqual = (first = [], second = []) => {
+  const normalizedFirst = normalizeFavorites(first);
+  const normalizedSecond = normalizeFavorites(second);
+
+  if (normalizedFirst.length !== normalizedSecond.length) {
+    return false;
+  }
+
+  return normalizedFirst.every((item, index) => {
+    const other = normalizedSecond[index];
+    return JSON.stringify(item) === JSON.stringify(other);
+  });
+};
+
+export const FavoritesProvider = ({ children }) => {
+  const { currentUser } = useAuth();
+  const [favorites, setFavoritesState] = useState(() => readLocalFavorites());
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const initializeFavorites = async () => {
+      const localFavorites = readLocalFavorites();
+
+      if (!currentUser) {
+        if (isMounted) {
+          setFavoritesState(localFavorites);
+        }
+        return;
+      }
+
+      try {
+        const remoteFavorites = await api.userData.getFavorites(currentUser.uid);
+        const remoteList = Array.isArray(remoteFavorites) ? remoteFavorites : [];
+        const mergedFavorites = mergeFavorites(remoteList, localFavorites);
+
+        if (isMounted) {
+          setFavoritesState(mergedFavorites);
+        }
+        writeLocalFavorites(mergedFavorites);
+
+        if (!favoritesAreEqual(remoteList, mergedFavorites)) {
+          try {
+            await api.userData.saveFavorites(currentUser.uid, mergedFavorites);
+          } catch (syncError) {
+            logger.error('Failed to synchronize favorites with the server', syncError);
+          }
+        }
+      } catch (error) {
+        logger.warn('Unable to load remote favorites, falling back to local storage', error);
+        if (isMounted) {
+          setFavoritesState(localFavorites);
+        }
+      }
+    };
+
+    initializeFavorites();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [currentUser?.uid]);
+
+  const persistFavorites = useCallback(
+    (nextFavorites) => {
+      const safeFavorites = Array.isArray(nextFavorites) ? nextFavorites : [];
+      writeLocalFavorites(safeFavorites);
+
+      if (currentUser) {
+        api.userData.saveFavorites(currentUser.uid, safeFavorites).catch((error) => {
+          logger.error('Failed to persist favorites remotely', error);
+        });
+      }
+    },
+    [currentUser?.uid]
+  );
+
+  const updateFavorites = useCallback(
+    (updater) => {
+      setFavoritesState((previousFavorites) => {
+        const result = typeof updater === 'function' ? updater(previousFavorites) : updater;
+        const normalizedResult = Array.isArray(result) ? result : [];
+        if (favoritesAreEqual(previousFavorites, normalizedResult)) {
+          return previousFavorites;
+        }
+        persistFavorites(normalizedResult);
+        return normalizedResult;
+      });
+    },
+    [persistFavorites]
+  );
+
+  const toggleFavorite = useCallback(
+    (book) => {
+      if (!book) {
+        return;
+      }
+
+      updateFavorites((previousFavorites) => {
+        const key = getItemKey(book);
+        const exists = previousFavorites.some((item) => getItemKey(item) === key);
+
+        if (exists) {
+          return previousFavorites.filter((item) => getItemKey(item) !== key);
+        }
+
+        return [...previousFavorites, book];
+      });
+    },
+    [updateFavorites]
+  );
 
   return (
     <FavoritesContext.Provider value={{ favorites, toggleFavorite }}>


### PR DESCRIPTION
## Summary
- add REST helpers in the shared API module to read and write user favorites and cart data with authentication headers
- update the favorites context to sync with the remote API when a user is logged in and fall back to local storage otherwise
- enhance the cart context to merge local and remote items, persist updates remotely, and maintain a local-storage fallback during logout

## Testing
- npm test *(fails: existing Jest configuration does not support ESM-based tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c98eb250ac832a9c98456c53597368