### PR TITLE
Add language-aware error handling and localization tests

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,11 @@ const AppContent = () => {
   const [isAppLoading, setIsAppLoading] = useState(true);
   const [dashboardSection, setDashboardSection] = useState('overview');
   const { t, i18n } = useTranslation();
+  const activeLanguage = i18n.language || i18n.resolvedLanguage || 'ar';
+  const handleErrorWithLanguage = useCallback(
+    (error, context) => errorHandler.handleError(error, context, activeLanguage),
+    [activeLanguage],
+  );
   useDirection(i18n);
   const location = useLocation();
   const isAdmin = location.pathname.startsWith('/admin');
@@ -202,92 +207,92 @@ const AppContent = () => {
         // تحميل البيانات من Firebase
         const [b, a, c, _settings, o, pay, methods, currenciesData, languagesData, p, u, sliders, banners, feats, sellData, branchData, subs, msgs] = await Promise.all([
           api.getBooks().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:books');
+            const errorObject = handleErrorWithLanguage(error, 'data:books');
             showDataLoadError('books', errorObject);
             return [];
           }),
           api.getAuthors().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:authors');
+            const errorObject = handleErrorWithLanguage(error, 'data:authors');
             showDataLoadError('authors', errorObject);
             return [];
           }),
           api.getCategories().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:categories');
+            const errorObject = handleErrorWithLanguage(error, 'data:categories');
             showDataLoadError('categories', errorObject);
             return [];
           }),
           refreshSettings(true).catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:settings');
+            const errorObject = handleErrorWithLanguage(error, 'data:settings');
             showDataLoadError('settings', errorObject);
             return {};
           }),
           api.getOrders().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:orders');
+            const errorObject = handleErrorWithLanguage(error, 'data:orders');
             showDataLoadError('orders', errorObject);
             return [];
           }),
           api.getPayments().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:payments');
+            const errorObject = handleErrorWithLanguage(error, 'data:payments');
             showDataLoadError('payments', errorObject);
             return [];
           }),
           api.getPaymentMethods().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:payment-methods');
+            const errorObject = handleErrorWithLanguage(error, 'data:payment-methods');
             showDataLoadError('paymentMethods', errorObject);
             return [];
           }),
           api.getCurrencies().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:currencies');
+            const errorObject = handleErrorWithLanguage(error, 'data:currencies');
             showDataLoadError('currencies', errorObject);
             return [];
           }),
           api.getLanguages().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:languages');
+            const errorObject = handleErrorWithLanguage(error, 'data:languages');
             showDataLoadError('languages', errorObject);
             return [];
           }),
           api.getPlans().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:plans');
+            const errorObject = handleErrorWithLanguage(error, 'data:plans');
             showDataLoadError('plans', errorObject);
             return [];
           }),
           api.getUsers().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:users');
+            const errorObject = handleErrorWithLanguage(error, 'data:users');
             showDataLoadError('users', errorObject);
             return [];
           }),
           api.getSliders().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:sliders');
+            const errorObject = handleErrorWithLanguage(error, 'data:sliders');
             showDataLoadError('sliders', errorObject);
             return [];
           }),
           api.getBanners().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:banners');
+            const errorObject = handleErrorWithLanguage(error, 'data:banners');
             showDataLoadError('banners', errorObject);
             return [];
           }),
           api.getFeatures().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:features');
+            const errorObject = handleErrorWithLanguage(error, 'data:features');
             showDataLoadError('features', errorObject);
             return [];
           }),
           api.getSellers().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:sellers');
+            const errorObject = handleErrorWithLanguage(error, 'data:sellers');
             showDataLoadError('sellers', errorObject);
             return [];
           }),
           api.getBranches().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:branches');
+            const errorObject = handleErrorWithLanguage(error, 'data:branches');
             showDataLoadError('branches', errorObject);
             return [];
           }),
           api.getSubscriptions().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:subscriptions');
+            const errorObject = handleErrorWithLanguage(error, 'data:subscriptions');
             showDataLoadError('subscriptions', errorObject);
             return [];
           }),
           api.getMessages().catch(error => {
-            const errorObject = errorHandler.handleError(error, 'data:messages');
+            const errorObject = handleErrorWithLanguage(error, 'data:messages');
             showDataLoadError('messages', errorObject);
             return [];
           }),
@@ -323,7 +328,7 @@ const AppContent = () => {
         ]);
 
       } catch (error) {
-        const errorObject = errorHandler.handleError(error, 'data:initial-load');
+        const errorObject = handleErrorWithLanguage(error, 'data:initial-load');
         showDataLoadError('initialLoad', errorObject);
       } finally {
         // تأخير بسيط لتحسين تجربة التحميل وتجنب الوميض
@@ -526,7 +531,7 @@ const AppContent = () => {
       firebaseAuth.signOut().then(() => {
         toast({ title: t('app.toast.logout.success', { defaultValue: 'You have been signed out.' }) });
       }).catch(error => {
-        const errorObject = errorHandler.handleError(error, 'auth:signout');
+        const errorObject = handleErrorWithLanguage(error, 'auth:signout');
         toast({
           title: t('app.toast.logout.error.title', { defaultValue: 'Sign out failed' }),
           description: t('app.toast.logout.error.description', {

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { errorHandler } from '@/lib/errorHandler';
+import i18n from '@/lib/i18n.js';
 import { AlertTriangle, RefreshCw, Home, ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
 import logger from '@/lib/logger.js';
+
+const getCurrentLanguage = () => i18n.language || i18n.resolvedLanguage || 'ar';
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -22,7 +25,11 @@ class ErrorBoundary extends React.Component {
 
   componentDidCatch(error, errorInfo) {
     // تسجيل الخطأ
-    const errorObject = errorHandler.handleError(error, 'react:error-boundary');
+    const errorObject = errorHandler.handleError(
+      error,
+      'react:error-boundary',
+      getCurrentLanguage(),
+    );
     
     this.setState({
       error: error,
@@ -198,7 +205,11 @@ const ErrorFallback = ({ error, errorInfo, errorId, onReset }) => {
 // Hook لاستخدام Error Boundary
 export const useErrorHandler = () => {
   const handleError = (error, context = '') => {
-    const errorObject = errorHandler.handleError(error, context);
+    const errorObject = errorHandler.handleError(
+      error,
+      context,
+      getCurrentLanguage(),
+    );
     
     // يمكن إضافة منطق إضافي هنا مثل:
     // - إظهار toast notification

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,6 +1,7 @@
 import firebaseApi from './firebaseApi';
 import firebaseFunctionsApi from './firebaseFunctions';
 import { errorHandler } from './errorHandler';
+import { getActiveLanguage } from './languageUtils.js';
 import CheckoutService from './services/CheckoutService.js';
 import OrderService from './services/OrderService.js';
 import PaymentService from './services/PaymentService.js';
@@ -44,6 +45,9 @@ const ensureArrayResponse = (payload, key) => {
 
   return [];
 };
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 async function requestUserData(userId, resource, { method = 'GET', body } = {}) {
   const context = `user-data:${resource}:${userId || 'anonymous'}`;
@@ -107,7 +111,7 @@ async function requestUserData(userId, resource, { method = 'GET', body } = {}) 
 
     return null;
   } catch (error) {
-    throw errorHandler.handleError(error, context);
+    throw handleErrorWithLanguage(error, context);
   }
 }
 
@@ -117,7 +121,7 @@ const userDataApi = {
       const response = await requestUserData(userId, 'favorites');
       return ensureArrayResponse(response, 'favorites');
     } catch (error) {
-      throw errorHandler.handleError(error, `user-data:get-favorites:${userId}`);
+      throw handleErrorWithLanguage(error, `user-data:get-favorites:${userId}`);
     }
   },
 
@@ -132,7 +136,7 @@ const userDataApi = {
       });
       return response == null ? favorites : ensureArrayResponse(response, 'favorites');
     } catch (error) {
-      throw errorHandler.handleError(error, `user-data:save-favorites:${userId}`);
+      throw handleErrorWithLanguage(error, `user-data:save-favorites:${userId}`);
     }
   },
 
@@ -141,7 +145,7 @@ const userDataApi = {
       const response = await requestUserData(userId, 'cart');
       return ensureArrayResponse(response, 'items');
     } catch (error) {
-      throw errorHandler.handleError(error, `user-data:get-cart:${userId}`);
+      throw handleErrorWithLanguage(error, `user-data:get-cart:${userId}`);
     }
   },
 
@@ -156,7 +160,7 @@ const userDataApi = {
       });
       return response == null ? cartItems : ensureArrayResponse(response, 'items');
     } catch (error) {
-      throw errorHandler.handleError(error, `user-data:save-cart:${userId}`);
+      throw handleErrorWithLanguage(error, `user-data:save-cart:${userId}`);
     }
   }
 };
@@ -180,7 +184,7 @@ const api = {
       await encryptedCache.setItem('siteSettings', settings);
       return settings;
     } catch (error) {
-      throw errorHandler.handleError(error, 'settings:get');
+      throw handleErrorWithLanguage(error, 'settings:get');
     }
   },
 
@@ -201,7 +205,7 @@ const api = {
 
       return result;
     } catch (error) {
-      throw errorHandler.handleError(error, context);
+      throw handleErrorWithLanguage(error, context);
     }
   },
 
@@ -210,7 +214,7 @@ const api = {
     try {
       return await firebaseFunctionsApi.payments.createStripeIntent(data);
     } catch (error) {
-      throw errorHandler.handleError(error, 'stripe:payment-intent');
+      throw handleErrorWithLanguage(error, 'stripe:payment-intent');
     }
   },
 
@@ -219,7 +223,7 @@ const api = {
     try {
       return await firebaseFunctionsApi.payments.createPayPalOrder(data);
     } catch (error) {
-      throw errorHandler.handleError(error, 'paypal:order');
+      throw handleErrorWithLanguage(error, 'paypal:order');
     }
   },
 
@@ -260,7 +264,7 @@ const api = {
 
       return result;
     } catch (error) {
-      throw errorHandler.handleError(error, 'settings:update');
+      throw handleErrorWithLanguage(error, 'settings:update');
     }
   },
 
@@ -296,7 +300,7 @@ const api = {
       try {
         return await CheckoutService.createOrderWithCheckout(orderData);
       } catch (error) {
-        throw errorHandler.handleError(error, 'order:create');
+        throw handleErrorWithLanguage(error, 'order:create');
       }
     },
 
@@ -305,7 +309,7 @@ const api = {
       try {
         return await firebaseFunctionsApi.orders.process(orderData, paymentData);
       } catch (error) {
-        throw errorHandler.handleError(error, 'order:process');
+        throw handleErrorWithLanguage(error, 'order:process');
       }
     },
 
@@ -314,7 +318,7 @@ const api = {
       try {
         return await CheckoutService.getOrderDetails(orderId);
       } catch (error) {
-        throw errorHandler.handleError(error, `order:get:${orderId}`);
+        throw handleErrorWithLanguage(error, `order:get:${orderId}`);
       }
     },
 
@@ -323,7 +327,7 @@ const api = {
       try {
         return await CheckoutService.getCustomerOrders(customerId, status);
       } catch (error) {
-        throw errorHandler.handleError(error, `orders:customer:${customerId}`);
+        throw handleErrorWithLanguage(error, `orders:customer:${customerId}`);
       }
     },
 
@@ -332,7 +336,7 @@ const api = {
       try {
         return await CheckoutService.updateOrderStatus(orderId, newStatus, notes);
       } catch (error) {
-        throw errorHandler.handleError(error, `order:status:${orderId}`);
+        throw handleErrorWithLanguage(error, `order:status:${orderId}`);
       }
     },
 
@@ -341,7 +345,7 @@ const api = {
       try {
         return await OrderService.updateOrderStage(orderId, newStage, notes);
       } catch (error) {
-        throw errorHandler.handleError(error, `order:stage:${orderId}`);
+        throw handleErrorWithLanguage(error, `order:stage:${orderId}`);
       }
     },
 
@@ -350,7 +354,7 @@ const api = {
       try {
         return await CheckoutService.cancelOrder(orderId, reason);
       } catch (error) {
-        throw errorHandler.handleError(error, `order:cancel:${orderId}`);
+        throw handleErrorWithLanguage(error, `order:cancel:${orderId}`);
       }
     },
 
@@ -359,7 +363,7 @@ const api = {
       try {
         return await CheckoutService.addItemToOrder(orderId, itemData);
       } catch (error) {
-        throw errorHandler.handleError(error, `order:add-item:${orderId}`);
+        throw handleErrorWithLanguage(error, `order:add-item:${orderId}`);
       }
     },
 
@@ -368,7 +372,7 @@ const api = {
       try {
         return await CheckoutService.removeItemFromOrder(orderId, itemId);
       } catch (error) {
-        throw errorHandler.handleError(error, `order:remove-item:${orderId}`);
+        throw handleErrorWithLanguage(error, `order:remove-item:${orderId}`);
       }
     },
 
@@ -377,7 +381,7 @@ const api = {
       try {
         return await CheckoutService.recalculateOrderTotal(orderId);
       } catch (error) {
-        throw errorHandler.handleError(error, `order:recalculate:${orderId}`);
+        throw handleErrorWithLanguage(error, `order:recalculate:${orderId}`);
       }
     },
 
@@ -386,7 +390,7 @@ const api = {
       try {
         return await CheckoutService.getOrderStats(customerId);
       } catch (error) {
-        throw errorHandler.handleError(error, 'orders:stats');
+        throw handleErrorWithLanguage(error, 'orders:stats');
       }
     },
 
@@ -454,7 +458,7 @@ const api = {
           order: orderResult.order
         };
       } catch (error) {
-        throw errorHandler.handleError(error, 'order:checkout');
+        throw handleErrorWithLanguage(error, 'order:checkout');
       }
     },
 
@@ -463,7 +467,7 @@ const api = {
       try {
         return await OrderService.getAllOrders(filters);
       } catch (error) {
-        throw errorHandler.handleError(error, 'orders:get-all');
+        throw handleErrorWithLanguage(error, 'orders:get-all');
       }
     },
 
@@ -476,7 +480,7 @@ const api = {
           return await OrderService.getAllOrders();
         }
       } catch (error) {
-        throw errorHandler.handleError(error, 'orders:get');
+        throw handleErrorWithLanguage(error, 'orders:get');
       }
     },
 
@@ -485,7 +489,7 @@ const api = {
       try {
         return await OrderService.updateOrderItem(itemId, updateData);
       } catch (error) {
-        throw errorHandler.handleError(error, `order-item:update:${itemId}`);
+        throw handleErrorWithLanguage(error, `order-item:update:${itemId}`);
       }
     },
 
@@ -494,7 +498,7 @@ const api = {
       try {
         return await OrderService.deleteOrder(orderId);
       } catch (error) {
-        throw errorHandler.handleError(error, `order:delete:${orderId}`);
+        throw handleErrorWithLanguage(error, `order:delete:${orderId}`);
       }
     },
 
@@ -503,7 +507,7 @@ const api = {
       try {
         return await OrderService.refundOrderPayment(orderId, refundData);
       } catch (error) {
-        throw errorHandler.handleError(error, `order:refund:${orderId}`);
+        throw handleErrorWithLanguage(error, `order:refund:${orderId}`);
       }
     }
   },
@@ -515,7 +519,7 @@ const api = {
       try {
         return await unifiedPaymentApi.createPaymentIntent(paymentData);
       } catch (error) {
-        throw errorHandler.handleError(error, 'payment:create');
+        throw handleErrorWithLanguage(error, 'payment:create');
       }
     },
 
@@ -524,7 +528,7 @@ const api = {
       try {
         return await unifiedPaymentApi.confirmPayment(paymentId, paymentMethodData);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:process:${paymentId}`);
+        throw handleErrorWithLanguage(error, `payment:process:${paymentId}`);
       }
     },
 
@@ -533,7 +537,7 @@ const api = {
       try {
         return await unifiedPaymentApi.getPaymentById(paymentId);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:get:${paymentId}`);
+        throw handleErrorWithLanguage(error, `payment:get:${paymentId}`);
       }
     },
 
@@ -543,7 +547,7 @@ const api = {
         // في النظام الموحد، يتم تحديث الحالة تلقائياً
         return await unifiedPaymentApi.getPaymentById(paymentId);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:status:${paymentId}`);
+        throw handleErrorWithLanguage(error, `payment:status:${paymentId}`);
       }
     },
 
@@ -552,7 +556,7 @@ const api = {
       try {
         return await unifiedPaymentApi.refundPayment(paymentId, amount, reason);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:refund:${paymentId}`);
+        throw handleErrorWithLanguage(error, `payment:refund:${paymentId}`);
       }
     },
 
@@ -561,7 +565,7 @@ const api = {
       try {
         return await unifiedPaymentApi.getPaymentStats(customerId);
       } catch (error) {
-        throw errorHandler.handleError(error, 'payments:stats');
+        throw handleErrorWithLanguage(error, 'payments:stats');
       }
     },
 
@@ -570,7 +574,7 @@ const api = {
       try {
         return await unifiedPaymentApi.getAvailablePaymentMethods(orderData);
       } catch (error) {
-        throw errorHandler.handleError(error, 'payment:methods:get');
+        throw handleErrorWithLanguage(error, 'payment:methods:get');
       }
     },
 
@@ -579,7 +583,7 @@ const api = {
       try {
         return await unifiedPaymentApi.testProviderConnection(providerName);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:provider-test:${providerName}`);
+        throw handleErrorWithLanguage(error, `payment:provider-test:${providerName}`);
       }
     },
 
@@ -588,7 +592,7 @@ const api = {
       try {
         return await unifiedPaymentApi.updatePaymentSettings(settings);
       } catch (error) {
-        throw errorHandler.handleError(error, 'payment:settings:update');
+        throw handleErrorWithLanguage(error, 'payment:settings:update');
       }
     },
 
@@ -597,7 +601,7 @@ const api = {
       try {
         return await unifiedPaymentApi.getPaymentProviders();
       } catch (error) {
-        throw errorHandler.handleError(error, 'payment:providers:get');
+        throw handleErrorWithLanguage(error, 'payment:providers:get');
       }
     },
 
@@ -606,7 +610,7 @@ const api = {
       try {
         return await unifiedPaymentApi.createCustomer(providerName, customerData);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:customer-create:${providerName}`);
+        throw handleErrorWithLanguage(error, `payment:customer-create:${providerName}`);
       }
     },
 
@@ -615,7 +619,7 @@ const api = {
       try {
         return await unifiedPaymentApi.savePaymentMethod(providerName, customerId, paymentMethodData);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:method-save:${providerName}`);
+        throw handleErrorWithLanguage(error, `payment:method-save:${providerName}`);
       }
     },
 
@@ -624,7 +628,7 @@ const api = {
       try {
         return await unifiedPaymentApi.getCustomerPaymentMethods(providerName, customerId);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:customer-methods:${providerName}`);
+        throw handleErrorWithLanguage(error, `payment:customer-methods:${providerName}`);
       }
     },
 
@@ -633,7 +637,7 @@ const api = {
       try {
         return await unifiedPaymentApi.deletePaymentMethod(providerName, customerId, paymentMethodId);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:method-delete:${providerName}`);
+        throw handleErrorWithLanguage(error, `payment:method-delete:${providerName}`);
       }
     },
 
@@ -642,7 +646,7 @@ const api = {
       try {
         return await unifiedPaymentApi.calculatePaymentFees(amount, providerName);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:fees:${providerName}`);
+        throw handleErrorWithLanguage(error, `payment:fees:${providerName}`);
       }
     },
 
@@ -651,7 +655,7 @@ const api = {
       try {
         return await unifiedPaymentApi.isPaymentMethodAvailable(providerName, orderData);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:method-availability:${providerName}`);
+        throw handleErrorWithLanguage(error, `payment:method-availability:${providerName}`);
       }
     },
 
@@ -660,7 +664,7 @@ const api = {
       try {
         return await unifiedPaymentApi.handleWebhook(providerName, webhookData, signature);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:webhook:${providerName}`);
+        throw handleErrorWithLanguage(error, `payment:webhook:${providerName}`);
       }
     },
 
@@ -669,7 +673,7 @@ const api = {
       try {
         return await unifiedPaymentApi.cancelPayment(paymentId, reason);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:cancel:${paymentId}`);
+        throw handleErrorWithLanguage(error, `payment:cancel:${paymentId}`);
       }
     },
 
@@ -678,7 +682,7 @@ const api = {
       try {
         return await unifiedPaymentApi.getProviderInfo(providerName);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:provider-info:${providerName}`);
+        throw handleErrorWithLanguage(error, `payment:provider-info:${providerName}`);
       }
     },
 
@@ -687,7 +691,7 @@ const api = {
       try {
         return await unifiedPaymentApi.getPaymentLogs(paymentId, limit);
       } catch (error) {
-        throw errorHandler.handleError(error, `payment:logs:${paymentId}`);
+        throw handleErrorWithLanguage(error, `payment:logs:${paymentId}`);
       }
     }
   },
@@ -699,7 +703,7 @@ const api = {
       try {
         return await ShippingService.createShipping(shippingData);
       } catch (error) {
-        throw errorHandler.handleError(error, 'shipping:create');
+        throw handleErrorWithLanguage(error, 'shipping:create');
       }
     },
 
@@ -708,7 +712,7 @@ const api = {
       try {
         return await firebaseFunctionsApi.shipping.calculate(orderItems, shippingAddress, shippingMethod);
       } catch (error) {
-        throw errorHandler.handleError(error, 'shipping:cost-calculation');
+        throw handleErrorWithLanguage(error, 'shipping:cost-calculation');
       }
     },
 
@@ -722,7 +726,7 @@ const api = {
       try {
         return await ShippingService.updateShippingStatus(shippingId, newStatus, notes);
       } catch (error) {
-        throw errorHandler.handleError(error, `shipping:status:${shippingId}`);
+        throw handleErrorWithLanguage(error, `shipping:status:${shippingId}`);
       }
     },
 
@@ -731,7 +735,7 @@ const api = {
       try {
         return await ShippingService.addTrackingNumber(shippingId, trackingNumber, shippingCompany);
       } catch (error) {
-        throw errorHandler.handleError(error, `shipping:tracking:${shippingId}`);
+        throw handleErrorWithLanguage(error, `shipping:tracking:${shippingId}`);
       }
     },
 
@@ -740,7 +744,7 @@ const api = {
       try {
         return await ShippingService.getShippingStats();
       } catch (error) {
-        throw errorHandler.handleError(error, 'shipping:stats');
+        throw handleErrorWithLanguage(error, 'shipping:stats');
       }
     }
   },
@@ -752,7 +756,7 @@ const api = {
       try {
         return await ProductService.createProduct(productData);
       } catch (error) {
-        throw errorHandler.handleError(error, 'product:create');
+        throw handleErrorWithLanguage(error, 'product:create');
       }
     },
 
@@ -761,7 +765,7 @@ const api = {
       try {
         return await ProductService.getProductById(productId);
       } catch (error) {
-        throw errorHandler.handleError(error, `product:get:${productId}`);
+        throw handleErrorWithLanguage(error, `product:get:${productId}`);
       }
     },
 
@@ -770,7 +774,7 @@ const api = {
       try {
         return await ProductService.getAllProducts(filters);
       } catch (error) {
-        throw errorHandler.handleError(error, 'products:get-all');
+        throw handleErrorWithLanguage(error, 'products:get-all');
       }
     },
 
@@ -779,7 +783,7 @@ const api = {
       try {
         return await ProductService.searchProducts(query, filters);
       } catch (error) {
-        throw errorHandler.handleError(error, 'products:search');
+        throw handleErrorWithLanguage(error, 'products:search');
       }
     },
 
@@ -788,7 +792,7 @@ const api = {
       try {
         return await ProductService.getProductsByType(type);
       } catch (error) {
-        throw errorHandler.handleError(error, `products:type:${type}`);
+        throw handleErrorWithLanguage(error, `products:type:${type}`);
       }
     },
 
@@ -797,7 +801,7 @@ const api = {
       try {
         return await firebaseFunctionsApi.inventory.updateStock(productId, quantity, operation);
       } catch (error) {
-        throw errorHandler.handleError(error, `product:stock:${productId}`);
+        throw handleErrorWithLanguage(error, `product:stock:${productId}`);
       }
     },
 
@@ -806,7 +810,7 @@ const api = {
       try {
         return await ProductService.checkStockAvailability(productId, requestedQuantity);
       } catch (error) {
-        throw errorHandler.handleError(error, `product:stock-check:${productId}`);
+        throw handleErrorWithLanguage(error, `product:stock-check:${productId}`);
       }
     },
 
@@ -815,7 +819,7 @@ const api = {
       try {
         return await ProductService.getBestSellers(limit);
       } catch (error) {
-        throw errorHandler.handleError(error, 'products:best-sellers');
+        throw handleErrorWithLanguage(error, 'products:best-sellers');
       }
     },
 
@@ -824,7 +828,7 @@ const api = {
       try {
         return await ProductService.getNewProducts(limit);
       } catch (error) {
-        throw errorHandler.handleError(error, 'products:new');
+        throw handleErrorWithLanguage(error, 'products:new');
       }
     },
 
@@ -833,7 +837,7 @@ const api = {
       try {
         return await ProductService.getDiscountedProducts(limit);
       } catch (error) {
-        throw errorHandler.handleError(error, 'products:discounted');
+        throw handleErrorWithLanguage(error, 'products:discounted');
       }
     },
 
@@ -842,7 +846,7 @@ const api = {
       try {
         return await ProductService.getProductStats();
       } catch (error) {
-        throw errorHandler.handleError(error, 'products:stats');
+        throw handleErrorWithLanguage(error, 'products:stats');
       }
     },
 
@@ -851,7 +855,7 @@ const api = {
       try {
         return await ProductService.generateDownloadUrl(productId, orderId);
       } catch (error) {
-        throw errorHandler.handleError(error, `product:download-url:${productId}`);
+        throw handleErrorWithLanguage(error, `product:download-url:${productId}`);
       }
     }
   },
@@ -865,7 +869,7 @@ const api = {
       return { 
         connected: false, 
         message: errorHandler.getErrorMessage(error),
-        error: errorHandler.handleError(error, 'connection:check')
+        error: handleErrorWithLanguage(error, 'connection:check')
       };
     }
   },
@@ -884,7 +888,7 @@ const api = {
     try {
       return await CustomerService.getOrCreateCustomer(customerId, userData);
     } catch (error) {
-      throw errorHandler.handleError(error, `api:get-or-create-customer:${customerId}`);
+      throw handleErrorWithLanguage(error, `api:get-or-create-customer:${customerId}`);
     }
   },
   
@@ -893,7 +897,7 @@ const api = {
     try {
       return await CustomerService.addCustomerAddress(customerId, addressData, userData);
     } catch (error) {
-      throw errorHandler.handleError(error, `api:add-customer-address:${customerId}`);
+      throw handleErrorWithLanguage(error, `api:add-customer-address:${customerId}`);
     }
   },
   
@@ -902,7 +906,7 @@ const api = {
     try {
       return await CustomerService.addCustomerPaymentMethod(customerId, paymentData);
     } catch (error) {
-      throw errorHandler.handleError(error, `api:add-customer-payment:${customerId}`);
+      throw handleErrorWithLanguage(error, `api:add-customer-payment:${customerId}`);
     }
   },
   
@@ -911,7 +915,7 @@ const api = {
     try {
       return await CustomerService.updateCustomer(customerId, updateData);
     } catch (error) {
-      throw errorHandler.handleError(error, `api:update-customer:${customerId}`);
+      throw handleErrorWithLanguage(error, `api:update-customer:${customerId}`);
     }
   },
   
@@ -920,7 +924,7 @@ const api = {
     try {
       return await CustomerService.getCustomerById(customerId);
     } catch (error) {
-      throw errorHandler.handleError(error, `api:get-customer:${customerId}`);
+      throw handleErrorWithLanguage(error, `api:get-customer:${customerId}`);
     }
   },
   
@@ -930,7 +934,7 @@ const api = {
       const customer = await CustomerService.getOrCreateCustomer(customerId);
       return customer.addresses || [];
     } catch (error) {
-      throw errorHandler.handleError(error, `api:get-customer-addresses:${customerId}`);
+      throw handleErrorWithLanguage(error, `api:get-customer-addresses:${customerId}`);
     }
   },
   
@@ -940,7 +944,7 @@ const api = {
       const customer = await CustomerService.getOrCreateCustomer(customerId);
       return customer.paymentMethods || [];
     } catch (error) {
-      throw errorHandler.handleError(error, `api:get-customer-payment-methods:${customerId}`);
+      throw handleErrorWithLanguage(error, `api:get-customer-payment-methods:${customerId}`);
     }
   },
   
@@ -969,7 +973,7 @@ const api = {
         }
       }
     } catch (error) {
-      throw errorHandler.handleError(error, `api:get-customer-data:${customerId}`);
+      throw handleErrorWithLanguage(error, `api:get-customer-data:${customerId}`);
     }
   },
   userData: userDataApi,

--- a/src/lib/authContext.jsx
+++ b/src/lib/authContext.jsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { jwtAuthManager, firebaseAuth } from '@/lib/jwtAuth.js';
 import { errorHandler } from '@/lib/errorHandler.js';
 import logger from '@/lib/logger.js';
@@ -9,6 +10,8 @@ export const AuthProvider = ({ children }) => {
   const [currentUser, setCurrentUser] = useState(null);
   const [isAdmin, setIsAdmin] = useState(false);
   const [isCustomer, setIsCustomer] = useState(false);
+  const { i18n } = useTranslation();
+  const activeLanguage = i18n.language || i18n.resolvedLanguage || 'ar';
 
   useEffect(() => {
     const checkAuthStatus = () => {
@@ -22,7 +25,7 @@ export const AuthProvider = ({ children }) => {
           }
         }
       } catch (error) {
-        const errorObject = errorHandler.handleError(error, 'auth:status-check');
+        const errorObject = errorHandler.handleError(error, 'auth:status-check', activeLanguage);
         logger.error('Auth status check failed:', errorObject);
         jwtAuthManager.clearTokens();
         setIsCustomer(false);
@@ -31,7 +34,7 @@ export const AuthProvider = ({ children }) => {
       }
     };
     checkAuthStatus();
-  }, []);
+  }, [activeLanguage]);
 
   useEffect(() => {
     const unsubscribe = firebaseAuth.onAuthStateChange(async ({ user, isAuthenticated }) => {

--- a/src/lib/errorHandler.js
+++ b/src/lib/errorHandler.js
@@ -1,5 +1,10 @@
 // Error Handler System
 import logger from './logger.js';
+import {
+  DEFAULT_LANGUAGE,
+  getActiveLanguage,
+  resolveLanguage as resolveLanguageCode,
+} from './languageUtils.js';
 
 class ErrorHandler {
   constructor() {
@@ -44,7 +49,50 @@ class ErrorHandler {
         'firebase/unavailable': 'Firebase غير متاح حالياً',
         'firebase/unauthenticated': 'لم يتم تسجيل الدخول',
         'firebase/invalid-argument': 'معرف العنصر غير صالح',
-        
+        'firebase/connection-failed': 'فشل الاتصال بفايربيس',
+        'firebase/document-not-found': 'المستند غير موجود',
+
+        // أخطاء العربة
+        'cart/not-found': 'السلة غير موجودة',
+        'cart/no-shipping-address': 'عنوان الشحن مطلوب',
+        'cart/no-physical-items': 'لا توجد عناصر مادية للشحن',
+        'cart/invalid-shipping-method': 'طريقة الشحن غير صالحة',
+        'cart/invalid-payment-method': 'طريقة الدفع غير صالحة للسلة',
+        'cart/invalid-discount': 'كود الخصم غير صالح',
+        'cart/expired': 'انتهت صلاحية السلة',
+        'cart-item/not-found': 'عنصر السلة غير موجود',
+
+        // أخطاء التكوين
+        'config/api-base-url-missing': 'رابط واجهة البرمجة غير مضبوط',
+
+        // أخطاء العملاء
+        'customer/not-found': 'العميل غير موجود',
+
+        // أخطاء الإعدادات
+        'settings/import-validation-failed': 'فشل التحقق من إعدادات الاستيراد',
+        'settings/not-initialized': 'لم يتم تهيئة الإعدادات',
+        'settings/validation-failed': 'فشل التحقق من الإعدادات',
+
+        // أخطاء البوابات
+        'gateway/not-found': 'بوابة الدفع غير موجودة',
+
+        // أخطاء الطلبات
+        'order/not-found': 'الطلب غير موجود',
+        'order-not-found': 'الطلب غير موجود',
+        'order/cannot-cancel': 'لا يمكن إلغاء الطلب',
+        'order/cannot-modify': 'لا يمكن تعديل الطلب',
+        'order/invalid-stage-transition': 'انتقال غير صالح بين مراحل الطلب',
+        'order/creation-failed': 'فشل إنشاء الطلب',
+        'database/order-creation-failed': 'فشل إنشاء الطلب في قاعدة البيانات',
+
+        // أخطاء المنتجات
+        'product/not-found': 'المنتج غير موجود',
+        'product/not-digital': 'المنتج ليس رقمياً',
+        'product/insufficient-stock': 'كمية المنتج غير كافية',
+
+        // أخطاء الشحن
+        'shipping/not-found': 'طريقة الشحن غير موجودة',
+
         // أخطاء الأذونات المحددة
         'permission-denied': 'لا تملك صلاحية الوصول - يرجى تسجيل الدخول كمدير',
         'insufficient-permissions': 'صلاحيات غير كافية - يرجى تسجيل الدخول كمدير',
@@ -61,6 +109,9 @@ class ErrorHandler {
         'payment/card-declined': 'تم رفض البطاقة',
         'payment/expired-card': 'البطاقة منتهية الصلاحية',
         'payment/invalid-cvv': 'رمز CVV غير صحيح',
+        'payment/not-found': 'الدفعة غير موجودة',
+        'payment/cannot-refund': 'لا يمكن استرداد الدفعة',
+        'payment/unsupported-method': 'طريقة الدفع غير مدعومة',
         
         // أخطاء التحقق
         'validation/required': 'هذا الحقل مطلوب',
@@ -72,7 +123,22 @@ class ErrorHandler {
         'validation/date': 'التاريخ غير صحيح',
         'validation/file-size': 'حجم الملف كبير جداً',
         'validation/file-type': 'نوع الملف غير مدعوم',
-        
+        'validation/customer-creation-invalid': 'بيانات إنشاء العميل غير صالحة',
+        'validation/customer-update-invalid': 'بيانات تحديث العميل غير صالحة',
+        'validation/customer-invalid': 'بيانات العميل غير صالحة',
+        'validation/checkout-invalid': 'بيانات إتمام الطلب غير صالحة',
+        'validation/payment-invalid': 'بيانات الدفع غير صالحة',
+        'validation/product-invalid': 'بيانات المنتج غير صالحة',
+        'validation/shipping-invalid': 'بيانات الشحن غير صالحة',
+        'validation/stock-unavailable': 'الكمية المطلوبة غير متوفرة',
+        'validation/order-invalid': 'بيانات الطلب غير صالحة',
+        'validation/order-missing': 'معلومات الطلب مفقودة',
+        'validation/order-id-missing': 'معرف الطلب مطلوب',
+        'validation/invalid-order-id': 'معرف الطلب غير صالح',
+        'validation/user-id-missing': 'معرف المستخدم مطلوب',
+        'validation/invalid-data': 'البيانات غير صالحة',
+        'validation/missing-id': 'المعرف مطلوب',
+
         // أخطاء عامة
         'general/not-found': 'الصفحة المطلوبة غير موجودة',
         'general/server-error': 'خطأ في الخادم',
@@ -110,7 +176,50 @@ class ErrorHandler {
         'firebase/unavailable': 'Firebase unavailable',
         'firebase/unauthenticated': 'Not authenticated',
         'firebase/invalid-argument': 'Invalid item ID',
-        
+        'firebase/connection-failed': 'Failed to connect to Firebase',
+        'firebase/document-not-found': 'Document not found',
+
+        // Cart errors
+        'cart/not-found': 'Cart not found',
+        'cart/no-shipping-address': 'Shipping address is required',
+        'cart/no-physical-items': 'No physical items available for shipping',
+        'cart/invalid-shipping-method': 'Invalid shipping method',
+        'cart/invalid-payment-method': 'Invalid payment method for cart',
+        'cart/invalid-discount': 'Invalid discount code',
+        'cart/expired': 'Cart session expired',
+        'cart-item/not-found': 'Cart item not found',
+
+        // Configuration errors
+        'config/api-base-url-missing': 'API base URL is not configured',
+
+        // Customer errors
+        'customer/not-found': 'Customer not found',
+
+        // Settings errors
+        'settings/import-validation-failed': 'Settings import validation failed',
+        'settings/not-initialized': 'Settings have not been initialized',
+        'settings/validation-failed': 'Settings validation failed',
+
+        // Gateway errors
+        'gateway/not-found': 'Payment gateway not found',
+
+        // Order errors
+        'order/not-found': 'Order not found',
+        'order-not-found': 'Order not found',
+        'order/cannot-cancel': 'Order cannot be cancelled',
+        'order/cannot-modify': 'Order cannot be modified',
+        'order/invalid-stage-transition': 'Invalid order stage transition',
+        'order/creation-failed': 'Order creation failed',
+        'database/order-creation-failed': 'Failed to create order in the database',
+
+        // Product errors
+        'product/not-found': 'Product not found',
+        'product/not-digital': 'Product is not digital',
+        'product/insufficient-stock': 'Insufficient product stock',
+
+        // Shipping errors
+        'shipping/not-found': 'Shipping method not found',
+
         // Network errors
         'network/failed': 'Network connection failed',
         'network/timeout': 'Connection timeout',
@@ -123,7 +232,10 @@ class ErrorHandler {
         'payment/card-declined': 'Card declined',
         'payment/expired-card': 'Card expired',
         'payment/invalid-cvv': 'Invalid CVV',
-        
+        'payment/not-found': 'Payment not found',
+        'payment/cannot-refund': 'Payment cannot be refunded',
+        'payment/unsupported-method': 'Unsupported payment method',
+
         // Validation errors
         'validation/required': 'This field is required',
         'validation/email': 'Invalid email address',
@@ -134,7 +246,27 @@ class ErrorHandler {
         'validation/date': 'Invalid date',
         'validation/file-size': 'File size too large',
         'validation/file-type': 'File type not supported',
-        
+        'validation/type': 'Invalid value type',
+        'validation/minLength': 'Value is shorter than the minimum length',
+        'validation/maxLength': 'Value exceeds the maximum length',
+        'validation/pattern': 'Value does not match the required pattern',
+        'validation/customer-creation-invalid': 'Customer data is invalid',
+        'validation/customer-update-invalid': 'Customer update data is invalid',
+        'validation/customer-invalid': 'Customer data is invalid',
+        'validation/checkout-invalid': 'Checkout data is invalid',
+        'validation/payment-invalid': 'Payment information is invalid',
+        'validation/product-invalid': 'Product data is invalid',
+        'validation/shipping-invalid': 'Shipping data is invalid',
+        'validation/stock-unavailable': 'Requested stock is unavailable',
+        'validation/order-invalid': 'Order data is invalid',
+        'validation/order-missing': 'Order information is missing',
+        'validation/order-id-missing': 'Order ID is required',
+        'validation/invalid-order-id': 'Invalid order ID',
+        'validation/user-id-missing': 'User ID is required',
+        'validation/invalid-data': 'Provided data is invalid',
+        'validation/missing-id': 'Identifier is required',
+        'validation/email-exists': 'Email already exists',
+
         // General errors
         'general/not-found': 'Page not found',
         'general/server-error': 'Server error',
@@ -142,6 +274,30 @@ class ErrorHandler {
         'general/rate-limit': 'Rate limit exceeded, try later'
       }
     };
+
+    this.defaultLanguage = DEFAULT_LANGUAGE;
+    this.languageResolver = () => getActiveLanguage();
+  }
+
+  setLanguageResolver(resolver) {
+    if (typeof resolver === 'function') {
+      this.languageResolver = resolver;
+    }
+  }
+
+  resolveLanguage(language) {
+    if (language) {
+      return resolveLanguageCode(language);
+    }
+
+    if (typeof this.languageResolver === 'function') {
+      const resolved = this.languageResolver();
+      if (resolved) {
+        return resolveLanguageCode(resolved);
+      }
+    }
+
+    return this.defaultLanguage;
   }
 
   // تحديد نوع الخطأ
@@ -165,43 +321,64 @@ class ErrorHandler {
   }
 
   // الحصول على رسالة الخطأ
-  getErrorMessage(error, language = 'ar') {
-    const lang = this.errorMessages[language] || this.errorMessages.ar;
-    
+  getErrorMessage(error, language) {
+    const resolvedLanguage = this.resolveLanguage(language);
+    const lang = this.errorMessages[resolvedLanguage] || this.errorMessages[this.defaultLanguage];
+    const fallbackLang = this.errorMessages[this.defaultLanguage];
+
     // البحث عن رسالة خطأ محددة
-    if (error.code && lang[error.code]) {
-      return lang[error.code];
+    if (error.code) {
+      if (lang[error.code]) {
+        return lang[error.code];
+      }
+
+      if (fallbackLang[error.code]) {
+        return fallbackLang[error.code];
+      }
     }
-    
+
     // البحث عن رسالة خطأ عامة
-    if (error.message && lang[error.message]) {
-      return lang[error.message];
+    if (error.message) {
+      if (lang[error.message]) {
+        return lang[error.message];
+      }
+
+      if (fallbackLang[error.message]) {
+        return fallbackLang[error.message];
+      }
     }
-    
+
     // استخدام رسالة الخطأ الأصلية
     if (error.message) {
       return error.message;
     }
-    
+
     // رسالة افتراضية
-    return lang[this.getErrorType(error)];
+    const errorType = this.getErrorType(error);
+    return (
+      lang[errorType] ||
+      fallbackLang[errorType] ||
+      fallbackLang.UNKNOWN_ERROR
+    );
   }
 
   // معالجة الخطأ وإرجاع كائن منظم
-  handleError(error, context = '') {
+  handleError(error, context = '', language) {
     const errorType = this.getErrorType(error);
-    const message = this.getErrorMessage(error);
-    
+    const resolvedLanguage = this.resolveLanguage(language);
+    const message = this.getErrorMessage(error, resolvedLanguage);
+
     const errorObject = {
       type: errorType,
       code: error.code || 'unknown',
       message: message,
       originalError: error,
       context: context,
+      language: resolvedLanguage,
       timestamp: new Date().toISOString(),
       stack: error.stack
     };
-    
+
     // تسجيل الخطأ
     this.logError(errorObject);
     
@@ -210,7 +387,8 @@ class ErrorHandler {
 
   // تسجيل الأخطاء
   logError(errorObject) {
-    if (import.meta.env.VITE_APP_ENV === 'development') {
+    const env = (typeof import.meta !== 'undefined' && import.meta.env) || {};
+    if (env.VITE_APP_ENV === 'development') {
       logger.error('Error Handler:', errorObject);
     }
     
@@ -219,13 +397,13 @@ class ErrorHandler {
   }
 
   // إنشاء خطأ مخصص
-  createError(type, code, message, context = '') {
+  createError(type, code, message, context = '', language) {
     const error = new Error(message);
     error.code = code;
     error.type = type;
     error.context = context;
-    
-    return this.handleError(error, context);
+
+    return this.handleError(error, context, language);
   }
 
   // التحقق من صحة البيانات
@@ -286,24 +464,24 @@ class ErrorHandler {
   }
 
   // معالجة أخطاء API
-  handleApiError(response, context = '') {
+  handleApiError(response, context = '', language) {
     if (!response.ok) {
       const error = new Error(`HTTP ${response.status}: ${response.statusText}`);
       error.status = response.status;
       error.statusText = response.statusText;
-      
-      return this.handleError(error, context);
+
+      return this.handleError(error, context, language);
     }
-    
+
     return null;
   }
 
   // معالجة أخطاء Firebase
-  handleFirebaseError(error, context = '') {
+  handleFirebaseError(error, context = '', language) {
     if (error.code) {
-      return this.handleError(error, context);
+      return this.handleError(error, context, language);
     }
-    
+
     // أخطاء عامة
     if (error.message.includes('permission-denied')) {
       error.code = 'firebase/permission-denied';
@@ -312,24 +490,24 @@ class ErrorHandler {
     } else if (error.message.includes('unavailable')) {
       error.code = 'firebase/unavailable';
     }
-    
-    return this.handleError(error, context);
+
+    return this.handleError(error, context, language);
   }
 
   // معالجة أخطاء الدفع
-  handlePaymentError(error, context = '') {
+  handlePaymentError(error, context = '', language) {
     if (error.code && error.code.startsWith('payment/')) {
-      return this.handleError(error, context);
+      return this.handleError(error, context, language);
     }
-    
+
     // تحويل أخطاء Stripe
     if (error.type === 'StripeCardError') {
       error.code = `payment/${error.code}`;
     } else if (error.type === 'StripeInvalidRequestError') {
       error.code = 'payment/invalid-request';
     }
-    
-    return this.handleError(error, context);
+
+    return this.handleError(error, context, language);
   }
 
   // إعادة المحاولة مع تأخير

--- a/src/lib/firebase/baseApi.js
+++ b/src/lib/firebase/baseApi.js
@@ -16,7 +16,14 @@ import {
 import { db } from '../firebase.js';
 import { isImageSizeValid } from '../imageUtils.js';
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
 import logger from '../logger.js';
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
+
+const handleFirebaseErrorWithLanguage = (error, context) =>
+  errorHandler.handleFirebaseError(error, context, getActiveLanguage());
 
 // Process data before storing in Firestore
 async function processDataForStorage(data) {
@@ -48,7 +55,7 @@ async function processDataForStorage(data) {
 
     return processedData;
   } catch (error) {
-    throw errorHandler.handleError(error, 'data-processing');
+    throw handleErrorWithLanguage(error, 'data-processing');
   }
 }
 
@@ -67,7 +74,7 @@ async function getCollection(name) {
     const snapshot = await getDocs(collection(db, name));
     return snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
   } catch (error) {
-    throw errorHandler.handleFirebaseError(error, `collection:${name}`);
+    throw handleFirebaseErrorWithLanguage(error, `collection:${name}`);
   }
 }
 
@@ -95,7 +102,7 @@ async function addToCollection(name, data) {
     const ref = await addDoc(collection(db, name), processedData);
     return { ...processedData, id: ref.id };
   } catch (error) {
-    throw errorHandler.handleFirebaseError(error, `add:${name}`);
+    throw handleFirebaseErrorWithLanguage(error, `add:${name}`);
   }
 }
 
@@ -143,7 +150,7 @@ async function updateCollection(name, id, data) {
     }
     return { id: snap.id, ...snap.data() };
   } catch (error) {
-    throw errorHandler.handleFirebaseError(error, `update:${name}:${id}`);
+    throw handleFirebaseErrorWithLanguage(error, `update:${name}:${id}`);
   }
 }
 
@@ -169,7 +176,7 @@ async function deleteFromCollection(name, id) {
     }
     await deleteDoc(doc(db, name, id.toString()));
   } catch (error) {
-    throw errorHandler.handleFirebaseError(error, `delete:${name}:${id}`);
+    throw handleFirebaseErrorWithLanguage(error, `delete:${name}:${id}`);
   }
 }
 
@@ -199,7 +206,7 @@ async function getDocById(name, id) {
     }
     return null;
   } catch (error) {
-    throw errorHandler.handleFirebaseError(error, `get:${name}:${id}`);
+    throw handleFirebaseErrorWithLanguage(error, `get:${name}:${id}`);
   }
 }
 
@@ -210,7 +217,7 @@ async function setSingletonDoc(name, data) {
     const snap = await getDoc(ref);
     return { id: snap.id, ...snap.data() };
   } catch (error) {
-    throw errorHandler.handleFirebaseError(error, `set:${name}`);
+    throw handleFirebaseErrorWithLanguage(error, `set:${name}`);
   }
 }
 
@@ -221,7 +228,7 @@ async function setDocument(name, id, data) {
     const snap = await getDoc(ref);
     return { id: snap.id, ...snap.data() };
   } catch (error) {
-    throw errorHandler.handleFirebaseError(error, `set:${name}:${id}`);
+    throw handleFirebaseErrorWithLanguage(error, `set:${name}:${id}`);
   }
 }
 

--- a/src/lib/firebase/blogApi.js
+++ b/src/lib/firebase/blogApi.js
@@ -2,6 +2,10 @@ import { collection, addDoc, updateDoc, doc } from 'firebase/firestore';
 import baseApi from './baseApi.js';
 import { db } from '../firebase.js';
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
+
+const handleFirebaseErrorWithLanguage = (error, context) =>
+  errorHandler.handleFirebaseError(error, context, getActiveLanguage());
 
 export const getBlogPosts = () => baseApi.getCollection('blog_posts');
 export const getBlogPost = (id) => baseApi.getDocById('blog_posts', id);
@@ -32,7 +36,7 @@ export async function addBlogPostWithImage(data, imageFile) {
     }
     return { id: blogRef.id, ...blogData };
   } catch (error) {
-    throw errorHandler.handleFirebaseError(error, 'blog:add-with-image');
+    throw handleFirebaseErrorWithLanguage(error, 'blog:add-with-image');
   }
 }
 
@@ -46,7 +50,7 @@ export async function updateBlogPostWithImage(id, data, imageFile) {
     }
     return await updateBlogPost(id, data);
   } catch (error) {
-    throw errorHandler.handleFirebaseError(error, 'blog:update-with-image');
+    throw handleFirebaseErrorWithLanguage(error, 'blog:update-with-image');
   }
 }
 

--- a/src/lib/firebase/messagesApi.js
+++ b/src/lib/firebase/messagesApi.js
@@ -2,7 +2,11 @@ import { collection, query, where, getDocs } from 'firebase/firestore';
 import baseApi from './baseApi.js';
 import { db } from '../firebase.js';
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
 import logger from '../logger.js';
+
+const handleFirebaseErrorWithLanguage = (error, context) =>
+  errorHandler.handleFirebaseError(error, context, getActiveLanguage());
 
 export async function fetchAllMessages() {
   try {
@@ -22,7 +26,7 @@ export async function fetchAllMessages() {
         return dateB - dateA;
       });
     } catch (fallbackError) {
-      throw errorHandler.handleFirebaseError(fallbackError, 'messages:fetch-all-fallback');
+      throw handleFirebaseErrorWithLanguage(fallbackError, 'messages:fetch-all-fallback');
     }
   }
 }
@@ -52,7 +56,7 @@ export async function fetchUserMessages({ userId, email }) {
           return dateA - dateB;
         });
     } catch (fallbackError) {
-      throw errorHandler.handleFirebaseError(fallbackError, 'messages:fetch-user-fallback');
+      throw handleFirebaseErrorWithLanguage(fallbackError, 'messages:fetch-user-fallback');
     }
   }
 }

--- a/src/lib/firebase/ratingsApi.js
+++ b/src/lib/firebase/ratingsApi.js
@@ -2,6 +2,10 @@ import { collection, collectionGroup, getDocs, deleteDoc, doc } from 'firebase/f
 import baseApi from './baseApi.js';
 import { db } from '../firebase.js';
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
+
+const handleFirebaseErrorWithLanguage = (error, context) =>
+  errorHandler.handleFirebaseError(error, context, getActiveLanguage());
 
 export const getBookRatings = (bookId) => baseApi.getCollection(`books/${bookId}/ratings`);
 export const addBookRating = (bookId, data) => baseApi.addToCollection(`books/${bookId}/ratings`, data);
@@ -11,7 +15,7 @@ export async function getAllRatings() {
     const snap = await getDocs(collectionGroup(db, 'ratings'));
     return snap.docs.map(d => ({ id: d.id, bookId: d.ref.parent.parent.id, ...d.data() }));
   } catch (error) {
-    throw errorHandler.handleFirebaseError(error, 'ratings:get-all');
+    throw handleFirebaseErrorWithLanguage(error, 'ratings:get-all');
   }
 }
 
@@ -19,7 +23,7 @@ export async function deleteRating(bookId, ratingId) {
   try {
     await deleteDoc(doc(db, `books/${bookId}/ratings/${ratingId}`));
   } catch (error) {
-    throw errorHandler.handleFirebaseError(error, `ratings:delete:${bookId}:${ratingId}`);
+    throw handleFirebaseErrorWithLanguage(error, `ratings:delete:${bookId}:${ratingId}`);
   }
 }
 

--- a/src/lib/firebase/settingsApi.js
+++ b/src/lib/firebase/settingsApi.js
@@ -2,6 +2,10 @@ import { doc, getDoc } from 'firebase/firestore';
 import baseApi from './baseApi.js';
 import { db } from '../firebase.js';
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
+
+const handleFirebaseErrorWithLanguage = (error, context) =>
+  errorHandler.handleFirebaseError(error, context, getActiveLanguage());
 
 export async function getSettings() {
   try {
@@ -19,7 +23,7 @@ export async function getSettings() {
 
     return data;
   } catch (error) {
-    throw errorHandler.handleFirebaseError(error, 'settings:get');
+    throw handleFirebaseErrorWithLanguage(error, 'settings:get');
   }
 }
 
@@ -38,7 +42,7 @@ export async function updateSettings(data = {}) {
 
     return updated;
   } catch (error) {
-    throw errorHandler.handleFirebaseError(error, 'settings:update');
+    throw handleFirebaseErrorWithLanguage(error, 'settings:update');
   }
 }
 

--- a/src/lib/languageUtils.js
+++ b/src/lib/languageUtils.js
@@ -1,0 +1,37 @@
+import i18n from './i18n.js';
+import { SUPPORTED_LANGUAGES } from './languages.js';
+
+export const DEFAULT_LANGUAGE = 'ar';
+
+export const normalizeLanguage = (language) => {
+  if (!language || typeof language !== 'string') {
+    return null;
+  }
+
+  return language.toLowerCase().split('-')[0];
+};
+
+export const isSupportedLanguage = (language) =>
+  Boolean(language) && SUPPORTED_LANGUAGES.some(({ code }) => code === language);
+
+export const resolveLanguage = (language) => {
+  const normalized = normalizeLanguage(language);
+
+  if (normalized && isSupportedLanguage(normalized)) {
+    return normalized;
+  }
+
+  return DEFAULT_LANGUAGE;
+};
+
+export const getActiveLanguage = () => {
+  if (i18n && typeof i18n === 'object') {
+    const activeLanguage = i18n.language || i18n.resolvedLanguage;
+
+    if (activeLanguage) {
+      return resolveLanguage(activeLanguage);
+    }
+  }
+
+  return DEFAULT_LANGUAGE;
+};

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,7 +1,8 @@
 const levels = { debug: 0, info: 1, error: 2, none: 3 };
 
-const isProd = import.meta.env.PROD;
-const envLevel = (import.meta.env.VITE_LOG_LEVEL || '').toLowerCase();
+const env = (typeof import.meta !== 'undefined' && import.meta.env) || {};
+const isProd = Boolean(env.PROD);
+const envLevel = (env.VITE_LOG_LEVEL || '').toLowerCase();
 let currentLevel = levels[envLevel];
 if (currentLevel === undefined) {
   currentLevel = isProd ? levels.error : levels.debug;

--- a/src/lib/services/CartService.js
+++ b/src/lib/services/CartService.js
@@ -3,10 +3,14 @@
  */
 
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
 import firebaseApi from '../firebase/baseApi.js';
 import ProductService from './ProductService.js';
 import StoreSettingsService from './StoreSettingsService.js';
 import logger from '../logger.js';
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 export class CartService {
   constructor() {
@@ -47,7 +51,7 @@ export class CartService {
       return cart;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'cart-creation');
+      throw handleErrorWithLanguage(error, 'cart-creation');
     }
   }
 
@@ -80,7 +84,7 @@ export class CartService {
       return cartDoc;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart:${cartId}`);
     }
   }
 
@@ -101,7 +105,7 @@ export class CartService {
         throw error;
       }
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-get-or-create:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-get-or-create:${cartId}`);
     }
   }
 
@@ -127,7 +131,7 @@ export class CartService {
       return customerCart;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-cart:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer-cart:${customerId}`);
     }
   }
 
@@ -205,7 +209,7 @@ export class CartService {
       return await this.getCart(cartId);
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-add:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-add:${cartId}`);
     }
   }
 
@@ -260,7 +264,7 @@ export class CartService {
       return await this.getCart(cartId);
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-update:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-update:${cartId}`);
     }
   }
 
@@ -296,7 +300,7 @@ export class CartService {
       return await this.getCart(cartId);
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-remove:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-remove:${cartId}`);
     }
   }
 
@@ -353,7 +357,7 @@ export class CartService {
       };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-recalculate:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-recalculate:${cartId}`);
     }
   }
 
@@ -387,7 +391,7 @@ export class CartService {
       return await this.getCart(cartId);
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-shipping:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-shipping:${cartId}`);
     }
   }
 
@@ -437,7 +441,7 @@ export class CartService {
       return await this.getCart(cartId);
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-shipping-method:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-shipping-method:${cartId}`);
     }
   }
 
@@ -470,7 +474,7 @@ export class CartService {
       return await this.getCart(cartId);
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-payment-method:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-payment-method:${cartId}`);
     }
   }
 
@@ -515,7 +519,7 @@ export class CartService {
       return await this.getCart(cartId);
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-discount:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-discount:${cartId}`);
     }
   }
 
@@ -536,7 +540,7 @@ export class CartService {
       return await this.getCart(cartId);
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-discount-remove:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-discount-remove:${cartId}`);
     }
   }
 
@@ -553,7 +557,7 @@ export class CartService {
       return await this.getCart(cartId);
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-notes:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-notes:${cartId}`);
     }
   }
 
@@ -587,7 +591,7 @@ export class CartService {
       return await this.getCart(cart.id);
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-update:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-update:${cartId}`);
     }
   }
 
@@ -614,7 +618,7 @@ export class CartService {
       return { success: true, message: 'تم مسح السلة بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-clear:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-clear:${cartId}`);
     }
   }
 
@@ -627,7 +631,7 @@ export class CartService {
       return { success: true, message: 'تم حذف السلة بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-delete:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-delete:${cartId}`);
     }
   }
 
@@ -640,7 +644,7 @@ export class CartService {
       return { success: true, message: 'تم مسح السلة منتهية الصلاحية' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `cart-expired:${cartId}`);
+      throw handleErrorWithLanguage(error, `cart-expired:${cartId}`);
     }
   }
 
@@ -699,7 +703,7 @@ export class CartService {
       return stats;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'cart-stats');
+      throw handleErrorWithLanguage(error, 'cart-stats');
     }
   }
 }

--- a/src/lib/services/CheckoutService.js
+++ b/src/lib/services/CheckoutService.js
@@ -8,6 +8,7 @@ import { Payment } from '../models/Payment.js';
 import { Shipping } from '../models/Shipping.js';
 import schemas from '../../../shared/schemas.js';
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
 import OrderService from './OrderService.js';
 import PaymentService from './PaymentService.js';
 import ShippingService from './ShippingService.js';
@@ -15,6 +16,9 @@ import ProductService from './ProductService.js';
 import logger from '../logger.js';
 
 const { Schemas, validateData } = schemas;
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 export class CheckoutService {
   constructor() {
@@ -307,7 +311,7 @@ export class CheckoutService {
       };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'checkout-creation');
+      throw handleErrorWithLanguage(error, 'checkout-creation');
     }
   }
 
@@ -350,7 +354,7 @@ export class CheckoutService {
       };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'cost-calculation');
+      throw handleErrorWithLanguage(error, 'cost-calculation');
     }
   }
 
@@ -374,7 +378,7 @@ export class CheckoutService {
       return { available: true, message: 'جميع المنتجات متوفرة في المخزون' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'stock-availability-check');
+      throw handleErrorWithLanguage(error, 'stock-availability-check');
     }
   }
 
@@ -513,7 +517,7 @@ export class CheckoutService {
       const result = await this.orderService.cancelOrder(orderId, reason);
       return result;
     } catch (error) {
-      throw errorHandler.handleError(error, `order-cancellation:${orderId}`);
+      throw handleErrorWithLanguage(error, `order-cancellation:${orderId}`);
     }
   }
 
@@ -525,7 +529,7 @@ export class CheckoutService {
       const result = await this.orderService.updateOrderStatus(orderId, newStatus, notes);
       return result;
     } catch (error) {
-      throw errorHandler.handleError(error, `order-status-update:${orderId}`);
+      throw handleErrorWithLanguage(error, `order-status-update:${orderId}`);
     }
   }
 
@@ -537,7 +541,7 @@ export class CheckoutService {
       const order = await this.orderService.getOrderById(orderId);
       return order;
     } catch (error) {
-      throw errorHandler.handleError(error, `order-details:${orderId}`);
+      throw handleErrorWithLanguage(error, `order-details:${orderId}`);
     }
   }
 
@@ -549,7 +553,7 @@ export class CheckoutService {
       const orders = await this.orderService.getCustomerOrders(customerId, status);
       return orders;
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-orders:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer-orders:${customerId}`);
     }
   }
 
@@ -561,7 +565,7 @@ export class CheckoutService {
       const result = await this.orderService.addItemToOrder(orderId, itemData);
       return result;
     } catch (error) {
-      throw errorHandler.handleError(error, `add-item-to-order:${orderId}`);
+      throw handleErrorWithLanguage(error, `add-item-to-order:${orderId}`);
     }
   }
 
@@ -573,7 +577,7 @@ export class CheckoutService {
       const result = await this.orderService.removeItemFromOrder(orderId, itemId);
       return result;
     } catch (error) {
-      throw errorHandler.handleError(error, `remove-item-from-order:${orderId}`);
+      throw handleErrorWithLanguage(error, `remove-item-from-order:${orderId}`);
     }
   }
 
@@ -585,7 +589,7 @@ export class CheckoutService {
       const total = await this.orderService.recalculateOrderTotal(orderId);
       return total;
     } catch (error) {
-      throw errorHandler.handleError(error, `recalculate-order-total:${orderId}`);
+      throw handleErrorWithLanguage(error, `recalculate-order-total:${orderId}`);
     }
   }
 
@@ -597,7 +601,7 @@ export class CheckoutService {
       const stats = await this.orderService.getOrderStats(customerId);
       return stats;
     } catch (error) {
-      throw errorHandler.handleError(error, 'order-stats');
+      throw handleErrorWithLanguage(error, 'order-stats');
     }
   }
 
@@ -609,7 +613,7 @@ export class CheckoutService {
       const stats = await this.paymentService.getPaymentStats(customerId);
       return stats;
     } catch (error) {
-      throw errorHandler.handleError(error, 'payment-stats');
+      throw handleErrorWithLanguage(error, 'payment-stats');
     }
   }
 
@@ -621,7 +625,7 @@ export class CheckoutService {
       const stats = await this.shippingService.getShippingStats();
       return stats;
     } catch (error) {
-      throw errorHandler.handleError(error, 'shipping-stats');
+      throw handleErrorWithLanguage(error, 'shipping-stats');
     }
   }
 
@@ -692,7 +696,7 @@ export class CheckoutService {
 
       return paymentResult;
     } catch (error) {
-      throw errorHandler.handleError(error, `advanced-payment:${orderId}`);
+      throw handleErrorWithLanguage(error, `advanced-payment:${orderId}`);
     }
   }
 
@@ -734,7 +738,7 @@ export class CheckoutService {
         totalWithFees: orderTotal + this.paymentService.calculatePaymentFees(orderTotal, method.id)
       }));
     } catch (error) {
-      throw errorHandler.handleError(error, 'payment-methods-with-fees');
+      throw handleErrorWithLanguage(error, 'payment-methods-with-fees');
     }
   }
 
@@ -772,7 +776,7 @@ export class CheckoutService {
           );
       }
     } catch (error) {
-      throw errorHandler.handleError(error, `payment-link:${orderId}`);
+      throw handleErrorWithLanguage(error, `payment-link:${orderId}`);
     }
   }
 
@@ -791,7 +795,7 @@ export class CheckoutService {
 
       return paymentLink;
     } catch (error) {
-      throw errorHandler.handleError(error, 'tabby-payment-link');
+      throw handleErrorWithLanguage(error, 'tabby-payment-link');
     }
   }
 
@@ -810,7 +814,7 @@ export class CheckoutService {
 
       return paymentLink;
     } catch (error) {
-      throw errorHandler.handleError(error, 'tamara-payment-link');
+      throw handleErrorWithLanguage(error, 'tamara-payment-link');
     }
   }
 
@@ -828,7 +832,7 @@ export class CheckoutService {
 
       return paymentLink;
     } catch (error) {
-      throw errorHandler.handleError(error, 'stc-pay-payment-link');
+      throw handleErrorWithLanguage(error, 'stc-pay-payment-link');
     }
   }
 
@@ -846,7 +850,7 @@ export class CheckoutService {
 
       return paymentLink;
     } catch (error) {
-      throw errorHandler.handleError(error, 'urway-payment-link');
+      throw handleErrorWithLanguage(error, 'urway-payment-link');
     }
   }
 }

--- a/src/lib/services/CustomerService.js
+++ b/src/lib/services/CustomerService.js
@@ -4,7 +4,11 @@
 
 import Customer from '../models/Customer.js';
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
 import firebaseApi from '../firebase/baseApi.js';
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 export class CustomerService {
   constructor() {
@@ -48,7 +52,7 @@ export class CustomerService {
       return customer.toObject();
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'customer-creation');
+      throw handleErrorWithLanguage(error, 'customer-creation');
     }
   }
 
@@ -72,7 +76,7 @@ export class CustomerService {
       return customer;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer:${customerId}`);
     }
   }
 
@@ -118,7 +122,7 @@ export class CustomerService {
       return customer.toObject();
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-get-or-create:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer-get-or-create:${customerId}`);
     }
   }
 
@@ -133,7 +137,7 @@ export class CustomerService {
       return customer ? new Customer(customer).toObject() : null;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer:email:${email}`);
+      throw handleErrorWithLanguage(error, `customer:email:${email}`);
     }
   }
 
@@ -175,7 +179,7 @@ export class CustomerService {
       return updatedCustomer.toObject();
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-update:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer-update:${customerId}`);
     }
   }
 
@@ -200,7 +204,7 @@ export class CustomerService {
       return { success: true, message: 'تم حذف العميل بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-delete:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer-delete:${customerId}`);
     }
   }
 
@@ -239,7 +243,7 @@ export class CustomerService {
       return newAddress;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-address-add:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer-address-add:${customerId}`);
     }
   }
 
@@ -278,7 +282,7 @@ export class CustomerService {
       return updatedAddress;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-address-update:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer-address-update:${customerId}`);
     }
   }
 
@@ -317,7 +321,7 @@ export class CustomerService {
       return result;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-address-remove:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer-address-remove:${customerId}`);
     }
   }
 
@@ -355,7 +359,7 @@ export class CustomerService {
       return newPaymentMethod;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-payment-add:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer-payment-add:${customerId}`);
     }
   }
 
@@ -393,7 +397,7 @@ export class CustomerService {
       return updatedPaymentMethod;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-payment-update:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer-payment-update:${customerId}`);
     }
   }
 
@@ -431,7 +435,7 @@ export class CustomerService {
       return result;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-payment-remove:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer-payment-remove:${customerId}`);
     }
   }
 
@@ -478,7 +482,7 @@ export class CustomerService {
       };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-order-update:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer-order-update:${customerId}`);
     }
   }
 
@@ -526,7 +530,7 @@ export class CustomerService {
       return customers.map(customer => new Customer(customer).toObject());
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'customer-search');
+      throw handleErrorWithLanguage(error, 'customer-search');
     }
   }
 
@@ -627,7 +631,7 @@ export class CustomerService {
       return stats;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'customer-stats');
+      throw handleErrorWithLanguage(error, 'customer-stats');
     }
   }
 
@@ -655,7 +659,7 @@ export class CustomerService {
       return sortedCustomers.slice(0, limit).map(customer => new Customer(customer).toObject());
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'customer-top');
+      throw handleErrorWithLanguage(error, 'customer-top');
     }
   }
 }

--- a/src/lib/services/OrderService.js
+++ b/src/lib/services/OrderService.js
@@ -7,6 +7,7 @@ import { OrderItem } from '../models/OrderItem.js';
 import { Payment } from '../models/Payment.js';
 import { Shipping } from '../models/Shipping.js';
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
 import firebaseApi from '../firebase/baseApi.js';
 import logger from '../logger.js';
 
@@ -14,6 +15,9 @@ import { createOrder as createOrderHandler } from './order/createOrder.js';
 import { updateOrderStatus as updateOrderStatusHandler, updateOrderStage as updateOrderStageHandler } from './order/updateOrder.js';
 import { updateOrderItem as updateOrderItemHandler } from './order/orderItems.js';
 import { refundOrderPayment as refundOrderPaymentHandler } from './order/refundPayment.js';
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 export class OrderService {
   constructor() {
@@ -84,7 +88,7 @@ export class OrderService {
       };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `order:${orderId}`);
+      throw handleErrorWithLanguage(error, `order:${orderId}`);
     }
   }
 
@@ -109,7 +113,7 @@ export class OrderService {
       return orders.map(order => new Order(order).toObject());
 
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-orders:${customerId}`);
+      throw handleErrorWithLanguage(error, `customer-orders:${customerId}`);
     }
   }
 
@@ -283,7 +287,7 @@ export class OrderService {
       return { success: true, message: 'تم إلغاء الطلب بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `order-cancel:${orderId}`);
+      throw handleErrorWithLanguage(error, `order-cancel:${orderId}`);
     }
   }
 
@@ -325,7 +329,7 @@ export class OrderService {
       return savedItem;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `order-add-item:${orderId}`);
+      throw handleErrorWithLanguage(error, `order-add-item:${orderId}`);
     }
   }
 
@@ -363,7 +367,7 @@ export class OrderService {
       return { success: true, message: 'تم إزالة المنتج بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `order-remove-item:${orderId}`);
+      throw handleErrorWithLanguage(error, `order-remove-item:${orderId}`);
     }
   }
 
@@ -390,7 +394,7 @@ export class OrderService {
       return orderModel.total;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `order-recalculate:${orderId}`);
+      throw handleErrorWithLanguage(error, `order-recalculate:${orderId}`);
     }
   }
 
@@ -472,7 +476,7 @@ export class OrderService {
       return { success: true, message: 'تم استرداد الدفع بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `payment-refund:${paymentId}`);
+      throw handleErrorWithLanguage(error, `payment-refund:${paymentId}`);
     }
   }
 
@@ -501,7 +505,7 @@ export class OrderService {
       return stats;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'order-stats');
+      throw handleErrorWithLanguage(error, 'order-stats');
     }
   }
 
@@ -557,7 +561,7 @@ export class OrderService {
       };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'orders:get-all');
+      throw handleErrorWithLanguage(error, 'orders:get-all');
     }
   }
 
@@ -618,7 +622,7 @@ export class OrderService {
       };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `order-delete:${orderId}`);
+      throw handleErrorWithLanguage(error, `order-delete:${orderId}`);
     }
   }
 }

--- a/src/lib/services/PaymentService.js
+++ b/src/lib/services/PaymentService.js
@@ -5,11 +5,15 @@
 import { Payment, PAYMENT_STATUSES, PAYMENT_METHODS } from '../models/Payment.js';
 import schemas from '../../../shared/schemas.js';
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
 import firebaseApi from '../firebase/baseApi.js';
 import logger from '../logger.js';
 import { paymentManager } from '../payment/PaymentManager.js';
 
 const { Schemas, validateData } = schemas;
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 export class PaymentService {
   constructor() {
@@ -74,7 +78,7 @@ export class PaymentService {
       return { ...payment.toObject(), paymentIntent };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'payment-creation');
+      throw handleErrorWithLanguage(error, 'payment-creation');
     }
   }
 
@@ -122,7 +126,7 @@ export class PaymentService {
         error: error.message
       });
       
-      throw errorHandler.handleError(error, `payment-process:${paymentId}`);
+      throw handleErrorWithLanguage(error, `payment-process:${paymentId}`);
     }
   }
 
@@ -145,7 +149,7 @@ export class PaymentService {
       return new Payment(paymentDoc).toObject();
 
     } catch (error) {
-      throw errorHandler.handleError(error, `payment:${paymentId}`);
+      throw handleErrorWithLanguage(error, `payment:${paymentId}`);
     }
   }
 
@@ -160,7 +164,7 @@ export class PaymentService {
         .map(payment => new Payment(payment).toObject());
 
     } catch (error) {
-      throw errorHandler.handleError(error, `order-payments:${orderId}`);
+      throw handleErrorWithLanguage(error, `order-payments:${orderId}`);
     }
   }
 
@@ -192,7 +196,7 @@ export class PaymentService {
       return paymentModel.toObject();
 
     } catch (error) {
-      throw errorHandler.handleError(error, `payment-status:${paymentId}`);
+      throw handleErrorWithLanguage(error, `payment-status:${paymentId}`);
     }
   }
 
@@ -230,7 +234,7 @@ export class PaymentService {
       return { success: true, message: 'تم استرداد الدفع بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `payment-refund:${paymentId}`);
+      throw handleErrorWithLanguage(error, `payment-refund:${paymentId}`);
     }
   }
 
@@ -259,7 +263,7 @@ export class PaymentService {
       return stats;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'payment-stats');
+      throw handleErrorWithLanguage(error, 'payment-stats');
     }
   }
 
@@ -322,7 +326,7 @@ export class PaymentService {
       
       return availableMethods;
     } catch (error) {
-      throw errorHandler.handleError(error, 'payment-methods:get');
+      throw handleErrorWithLanguage(error, 'payment-methods:get');
     }
   }
 

--- a/src/lib/services/ProductService.js
+++ b/src/lib/services/ProductService.js
@@ -3,7 +3,11 @@
  */
 
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
 import firebaseApi from '../firebase/baseApi.js';
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 export class ProductService {
   constructor() {
@@ -40,7 +44,7 @@ export class ProductService {
       return product;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'product-creation');
+      throw handleErrorWithLanguage(error, 'product-creation');
     }
   }
 
@@ -62,7 +66,7 @@ export class ProductService {
       return product;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `product:${productId}`);
+      throw handleErrorWithLanguage(error, `product:${productId}`);
     }
   }
 
@@ -118,7 +122,7 @@ export class ProductService {
       return products;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'products-get-all');
+      throw handleErrorWithLanguage(error, 'products-get-all');
     }
   }
 
@@ -140,7 +144,7 @@ export class ProductService {
       // التحقق من صحة البيانات المحدثة
       const validationErrors = this.validateProduct({ ...product, ...updateData });
       if (validationErrors.length > 0) {
-        throw errorHandler.handleError(
+        throw handleErrorWithLanguage(
           'VALIDATION',
           'validation/product-update-invalid',
           `خطأ في بيانات التحديث: ${validationErrors.join(', ')}`,
@@ -160,7 +164,7 @@ export class ProductService {
       return { success: true, message: 'تم تحديث المنتج بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `product-update:${productId}`);
+      throw handleErrorWithLanguage(error, `product-update:${productId}`);
     }
   }
 
@@ -185,7 +189,7 @@ export class ProductService {
       return { success: true, message: 'تم حذف المنتج بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `product-delete:${productId}`);
+      throw handleErrorWithLanguage(error, `product-delete:${productId}`);
     }
   }
 
@@ -227,7 +231,7 @@ export class ProductService {
       return products;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'product-search');
+      throw handleErrorWithLanguage(error, 'product-search');
     }
   }
 
@@ -240,7 +244,7 @@ export class ProductService {
       return products;
 
     } catch (error) {
-      throw errorHandler.handleError(error, `products-by-type:${type}`);
+      throw handleErrorWithLanguage(error, `products-by-type:${type}`);
     }
   }
 
@@ -299,7 +303,7 @@ export class ProductService {
       return { success: true, newStock };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `stock-update:${productId}`);
+      throw handleErrorWithLanguage(error, `stock-update:${productId}`);
     }
   }
 
@@ -324,7 +328,7 @@ export class ProductService {
       };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `stock-check:${productId}`);
+      throw handleErrorWithLanguage(error, `stock-check:${productId}`);
     }
   }
 
@@ -343,7 +347,7 @@ export class ProductService {
       return bestSellers;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'best-sellers');
+      throw handleErrorWithLanguage(error, 'best-sellers');
     }
   }
 
@@ -362,7 +366,7 @@ export class ProductService {
       return newProducts;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'new-products');
+      throw handleErrorWithLanguage(error, 'new-products');
     }
   }
 
@@ -386,7 +390,7 @@ export class ProductService {
       return discountedProducts;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'discounted-products');
+      throw handleErrorWithLanguage(error, 'discounted-products');
     }
   }
 
@@ -521,7 +525,7 @@ export class ProductService {
       return stats;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'product-stats');
+      throw handleErrorWithLanguage(error, 'product-stats');
     }
   }
 
@@ -576,7 +580,7 @@ export class ProductService {
       };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `download-url:${productId}`);
+      throw handleErrorWithLanguage(error, `download-url:${productId}`);
     }
   }
 }

--- a/src/lib/services/ShippingService.js
+++ b/src/lib/services/ShippingService.js
@@ -4,7 +4,11 @@
 
 import { Shipping, SHIPPING_METHODS, SHIPPING_STATUSES } from '../models/Shipping.js';
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
 import firebaseApi from '../firebase/baseApi.js';
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 export class ShippingService {
   constructor() {
@@ -40,7 +44,7 @@ export class ShippingService {
       return shipping.toObject();
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'shipping-creation');
+      throw handleErrorWithLanguage(error, 'shipping-creation');
     }
   }
 
@@ -62,7 +66,7 @@ export class ShippingService {
       return new Shipping(shippingDoc).toObject();
 
     } catch (error) {
-      throw errorHandler.handleError(error, `shipping:${shippingId}`);
+      throw handleErrorWithLanguage(error, `shipping:${shippingId}`);
     }
   }
 
@@ -81,7 +85,7 @@ export class ShippingService {
       return new Shipping(shipping).toObject();
 
     } catch (error) {
-      throw errorHandler.handleError(error, `order-shipping:${orderId}`);
+      throw handleErrorWithLanguage(error, `order-shipping:${orderId}`);
     }
   }
 
@@ -123,7 +127,7 @@ export class ShippingService {
       return shippingModel.toObject();
 
     } catch (error) {
-      throw errorHandler.handleError(error, `shipping-status:${shippingId}`);
+      throw handleErrorWithLanguage(error, `shipping-status:${shippingId}`);
     }
   }
 
@@ -156,7 +160,7 @@ export class ShippingService {
       return shippingModel.toObject();
 
     } catch (error) {
-      throw errorHandler.handleError(error, `shipping-tracking:${shippingId}`);
+      throw handleErrorWithLanguage(error, `shipping-tracking:${shippingId}`);
     }
   }
 
@@ -182,7 +186,7 @@ export class ShippingService {
       };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'shipping-cost-calculation');
+      throw handleErrorWithLanguage(error, 'shipping-cost-calculation');
     }
   }
 
@@ -406,7 +410,7 @@ export class ShippingService {
       return stats;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'shipping-stats');
+      throw handleErrorWithLanguage(error, 'shipping-stats');
     }
   }
 
@@ -447,7 +451,7 @@ export class ShippingService {
       return shipping.map(ship => new Shipping(ship).toObject());
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'shipping-search');
+      throw handleErrorWithLanguage(error, 'shipping-search');
     }
   }
 
@@ -481,7 +485,7 @@ export class ShippingService {
       return { success: true, message: 'تم تحديث معلومات الشحن بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `shipping-update:${shippingId}`);
+      throw handleErrorWithLanguage(error, `shipping-update:${shippingId}`);
     }
   }
 
@@ -506,7 +510,7 @@ export class ShippingService {
       return { success: true, message: 'تم حذف معلومات الشحن بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `shipping-delete:${shippingId}`);
+      throw handleErrorWithLanguage(error, `shipping-delete:${shippingId}`);
     }
   }
 }

--- a/src/lib/services/StoreSettingsService.js
+++ b/src/lib/services/StoreSettingsService.js
@@ -4,8 +4,12 @@
 
 import StoreSettings from '../models/StoreSettings.js';
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
 import firebaseApi from '../firebase/baseApi.js';
 import logger from '../logger.js';
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 export class StoreSettingsService {
   constructor() {
@@ -38,7 +42,7 @@ export class StoreSettingsService {
       return this.settings;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:get');
+      throw handleErrorWithLanguage(error, 'store-settings:get');
     }
   }
 
@@ -73,7 +77,7 @@ export class StoreSettingsService {
       return { success: true, message: 'تم حفظ الإعدادات بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:save');
+      throw handleErrorWithLanguage(error, 'store-settings:save');
     }
   }
 
@@ -94,7 +98,7 @@ export class StoreSettingsService {
       return { success: true, message: 'تم تحديث الإعدادات بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:update');
+      throw handleErrorWithLanguage(error, 'store-settings:update');
     }
   }
 
@@ -109,7 +113,7 @@ export class StoreSettingsService {
       return { success: true, message: 'تم إعادة تعيين الإعدادات بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:reset');
+      throw handleErrorWithLanguage(error, 'store-settings:reset');
     }
   }
 
@@ -139,7 +143,7 @@ export class StoreSettingsService {
       return { success: true, message: 'تم تحديث إعدادات الشحن بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:shipping-update');
+      throw handleErrorWithLanguage(error, 'store-settings:shipping-update');
     }
   }
 
@@ -166,7 +170,7 @@ export class StoreSettingsService {
       return { success: true, message: 'تم تحديث إعدادات الدفع بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:payment-update');
+      throw handleErrorWithLanguage(error, 'store-settings:payment-update');
     }
   }
 
@@ -193,7 +197,7 @@ export class StoreSettingsService {
       return { success: true, message: 'تم تحديث إعدادات الضرائب بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:tax-update');
+      throw handleErrorWithLanguage(error, 'store-settings:tax-update');
     }
   }
 
@@ -223,7 +227,7 @@ export class StoreSettingsService {
       return { success: true, message: 'تم تحديث إعدادات الطلبات بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:order-update');
+      throw handleErrorWithLanguage(error, 'store-settings:order-update');
     }
   }
 
@@ -250,7 +254,7 @@ export class StoreSettingsService {
       return { success: true, message: 'تم تحديث إعدادات العملاء بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:customer-update');
+      throw handleErrorWithLanguage(error, 'store-settings:customer-update');
     }
   }
 
@@ -277,7 +281,7 @@ export class StoreSettingsService {
       return { success: true, message: 'تم تحديث إعدادات الإشعارات بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:notification-update');
+      throw handleErrorWithLanguage(error, 'store-settings:notification-update');
     }
   }
 
@@ -298,7 +302,7 @@ export class StoreSettingsService {
       return settings.getAvailableShippingMethods(country, orderAmount, productWeight);
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:shipping-methods');
+      throw handleErrorWithLanguage(error, 'store-settings:shipping-methods');
     }
   }
 
@@ -311,7 +315,7 @@ export class StoreSettingsService {
       return settings.getAvailablePaymentMethods();
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:payment-methods');
+      throw handleErrorWithLanguage(error, 'store-settings:payment-methods');
     }
   }
 
@@ -324,7 +328,7 @@ export class StoreSettingsService {
       return settings.getAvailablePaymentGateways();
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:payment-gateways');
+      throw handleErrorWithLanguage(error, 'store-settings:payment-gateways');
     }
   }
 
@@ -337,7 +341,7 @@ export class StoreSettingsService {
       return settings.calculateShippingCost(country, orderAmount, productWeight, shippingMethodId);
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:shipping-cost');
+      throw handleErrorWithLanguage(error, 'store-settings:shipping-cost');
     }
   }
 
@@ -350,7 +354,7 @@ export class StoreSettingsService {
       return settings.getShippingZoneByCountry(country);
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:shipping-zone');
+      throw handleErrorWithLanguage(error, 'store-settings:shipping-zone');
     }
   }
 
@@ -368,7 +372,7 @@ export class StoreSettingsService {
       };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:validate');
+      throw handleErrorWithLanguage(error, 'store-settings:validate');
     }
   }
 
@@ -381,7 +385,7 @@ export class StoreSettingsService {
       return settings.toObject();
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:export');
+      throw handleErrorWithLanguage(error, 'store-settings:export');
     }
   }
 
@@ -410,7 +414,7 @@ export class StoreSettingsService {
       return { success: true, message: 'تم استيراد الإعدادات بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:import');
+      throw handleErrorWithLanguage(error, 'store-settings:import');
     }
   }
 
@@ -436,7 +440,7 @@ export class StoreSettingsService {
       return stats;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'store-settings:stats');
+      throw handleErrorWithLanguage(error, 'store-settings:stats');
     }
   }
 
@@ -468,7 +472,7 @@ export class StoreSettingsService {
       return { success: true, message: 'تم تحديث بوابة الدفع بنجاح' };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `store-settings:gateway-update:${gatewayId}`);
+      throw handleErrorWithLanguage(error, `store-settings:gateway-update:${gatewayId}`);
     }
   }
 
@@ -495,7 +499,7 @@ export class StoreSettingsService {
       return { success: true, message: `تم ${status} بوابة الدفع بنجاح` };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `store-settings:gateway-toggle:${gatewayId}`);
+      throw handleErrorWithLanguage(error, `store-settings:gateway-toggle:${gatewayId}`);
     }
   }
 

--- a/src/lib/services/UnifiedPaymentService.js
+++ b/src/lib/services/UnifiedPaymentService.js
@@ -6,9 +6,13 @@
 import { paymentManager } from '../payment/PaymentManager.js';
 import { Payment } from '../models/Payment.js';
 import { errorHandler } from '../errorHandler.js';
+import { getActiveLanguage } from '../languageUtils.js';
 import firebaseApi from '../firebase/baseApi.js';
 import { getSettings, updateSettings } from '../firebase/settingsApi.js';
 import logger from '../logger.js';
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 export class UnifiedPaymentService {
   constructor() {
@@ -84,7 +88,7 @@ export class UnifiedPaymentService {
       };
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'payment-creation');
+      throw handleErrorWithLanguage(error, 'payment-creation');
     }
   }
 
@@ -140,7 +144,7 @@ export class UnifiedPaymentService {
         error: error.message
       });
       
-      throw errorHandler.handleError(error, `payment-process:${paymentId}`);
+      throw handleErrorWithLanguage(error, `payment-process:${paymentId}`);
     }
   }
 
@@ -162,7 +166,7 @@ export class UnifiedPaymentService {
       return new Payment(paymentDoc).toObject();
 
     } catch (error) {
-      throw errorHandler.handleError(error, `payment:${paymentId}`);
+      throw handleErrorWithLanguage(error, `payment:${paymentId}`);
     }
   }
 
@@ -177,7 +181,7 @@ export class UnifiedPaymentService {
         .map(payment => new Payment(payment).toObject());
 
     } catch (error) {
-      throw errorHandler.handleError(error, `order-payments:${orderId}`);
+      throw handleErrorWithLanguage(error, `order-payments:${orderId}`);
     }
   }
 
@@ -209,7 +213,7 @@ export class UnifiedPaymentService {
       return paymentModel.toObject();
 
     } catch (error) {
-      throw errorHandler.handleError(error, `payment-status:${paymentId}`);
+      throw handleErrorWithLanguage(error, `payment-status:${paymentId}`);
     }
   }
 
@@ -259,7 +263,7 @@ export class UnifiedPaymentService {
       return { success: true, message: 'تم استرداد الدفع بنجاح', refund: refundResult };
 
     } catch (error) {
-      throw errorHandler.handleError(error, `payment-refund:${paymentId}`);
+      throw handleErrorWithLanguage(error, `payment-refund:${paymentId}`);
     }
   }
 
@@ -288,7 +292,7 @@ export class UnifiedPaymentService {
       return stats;
 
     } catch (error) {
-      throw errorHandler.handleError(error, 'payment-stats');
+      throw handleErrorWithLanguage(error, 'payment-stats');
     }
   }
 
@@ -303,7 +307,7 @@ export class UnifiedPaymentService {
 
       return paymentManager.getAvailablePaymentMethods(orderData);
     } catch (error) {
-      throw errorHandler.handleError(error, 'payment-methods:get');
+      throw handleErrorWithLanguage(error, 'payment-methods:get');
     }
   }
 
@@ -318,7 +322,7 @@ export class UnifiedPaymentService {
 
       return await paymentManager.testProviderConnection(providerName);
     } catch (error) {
-      throw errorHandler.handleError(error, `provider-test:${providerName}`);
+      throw handleErrorWithLanguage(error, `provider-test:${providerName}`);
     }
   }
 
@@ -353,7 +357,7 @@ export class UnifiedPaymentService {
 
       return result;
     } catch (error) {
-      throw errorHandler.handleError(error, `webhook:${providerName}`);
+      throw handleErrorWithLanguage(error, `webhook:${providerName}`);
     }
   }
 
@@ -366,7 +370,7 @@ export class UnifiedPaymentService {
       const payment = payments.find(p => p.paymentIntentId === paymentIntentId);
       return payment ? new Payment(payment).toObject() : null;
     } catch (error) {
-      throw errorHandler.handleError(error, `payment-by-intent:${paymentIntentId}`);
+      throw handleErrorWithLanguage(error, `payment-by-intent:${paymentIntentId}`);
     }
   }
 
@@ -381,7 +385,7 @@ export class UnifiedPaymentService {
 
       return await paymentManager.createCustomer(providerName, customerData);
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-create:${providerName}`);
+      throw handleErrorWithLanguage(error, `customer-create:${providerName}`);
     }
   }
 
@@ -396,7 +400,7 @@ export class UnifiedPaymentService {
 
       return await paymentManager.savePaymentMethod(providerName, customerId, paymentMethodData);
     } catch (error) {
-      throw errorHandler.handleError(error, `payment-method-save:${providerName}`);
+      throw handleErrorWithLanguage(error, `payment-method-save:${providerName}`);
     }
   }
 
@@ -411,7 +415,7 @@ export class UnifiedPaymentService {
 
       return await paymentManager.getCustomerPaymentMethods(providerName, customerId);
     } catch (error) {
-      throw errorHandler.handleError(error, `customer-payment-methods:${providerName}`);
+      throw handleErrorWithLanguage(error, `customer-payment-methods:${providerName}`);
     }
   }
 
@@ -426,7 +430,7 @@ export class UnifiedPaymentService {
 
       return await paymentManager.deletePaymentMethod(providerName, customerId, paymentMethodId);
     } catch (error) {
-      throw errorHandler.handleError(error, `payment-method-delete:${providerName}`);
+      throw handleErrorWithLanguage(error, `payment-method-delete:${providerName}`);
     }
   }
 
@@ -452,7 +456,7 @@ export class UnifiedPaymentService {
 
       return { success: true };
     } catch (error) {
-      throw errorHandler.handleError(error, 'payment-settings-update');
+      throw handleErrorWithLanguage(error, 'payment-settings-update');
     }
   }
 
@@ -467,7 +471,7 @@ export class UnifiedPaymentService {
 
       return paymentManager.getAvailableProviders();
     } catch (error) {
-      throw errorHandler.handleError(error, 'provider-info');
+      throw handleErrorWithLanguage(error, 'provider-info');
     }
   }
 

--- a/src/lib/services/order/createOrder.js
+++ b/src/lib/services/order/createOrder.js
@@ -3,12 +3,16 @@ import { OrderItem } from '../../models/OrderItem.js';
 import { Shipping } from '../../models/Shipping.js';
 import schemas from '../../../../shared/schemas.js';
 import { errorHandler } from '../../errorHandler.js';
+import { getActiveLanguage } from '../../languageUtils.js';
 import firebaseApi from '../../firebase/baseApi.js';
 import logger from '../../logger.js';
 import { runTransaction, doc, collection, serverTimestamp } from 'firebase/firestore';
 import { db } from '../../firebase.js';
 
 const { Schemas, validateData } = schemas;
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 export async function createOrder(orderData) {
   try {
@@ -301,6 +305,6 @@ export async function createOrder(orderData) {
     return finalResult;
 
   } catch (error) {
-    throw errorHandler.handleError(error, 'order-creation');
+    throw handleErrorWithLanguage(error, 'order-creation');
   }
 }

--- a/src/lib/services/order/orderItems.js
+++ b/src/lib/services/order/orderItems.js
@@ -1,5 +1,9 @@
 import { errorHandler } from '../../errorHandler.js';
+import { getActiveLanguage } from '../../languageUtils.js';
 import firebaseApi from '../../firebase/baseApi.js';
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 export async function updateOrderItem(itemId, updateData) {
   try {
@@ -14,6 +18,6 @@ export async function updateOrderItem(itemId, updateData) {
     };
 
   } catch (error) {
-    throw errorHandler.handleError(error, `order-item:update:${itemId}`);
+    throw handleErrorWithLanguage(error, `order-item:update:${itemId}`);
   }
 }

--- a/src/lib/services/order/refundPayment.js
+++ b/src/lib/services/order/refundPayment.js
@@ -1,5 +1,9 @@
 import { errorHandler } from '../../errorHandler.js';
+import { getActiveLanguage } from '../../languageUtils.js';
 import firebaseApi from '../../firebase/baseApi.js';
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 export async function refundOrderPayment(orderId, refundData) {
   try {
@@ -40,6 +44,6 @@ export async function refundOrderPayment(orderId, refundData) {
     };
 
   } catch (error) {
-    throw errorHandler.handleError(error, `order-refund:${orderId}`);
+    throw handleErrorWithLanguage(error, `order-refund:${orderId}`);
   }
 }

--- a/src/lib/services/order/updateOrder.js
+++ b/src/lib/services/order/updateOrder.js
@@ -1,6 +1,10 @@
 import { Order } from '../../models/Order.js';
 import { errorHandler } from '../../errorHandler.js';
+import { getActiveLanguage } from '../../languageUtils.js';
 import firebaseApi from '../../firebase/baseApi.js';
+
+const handleErrorWithLanguage = (error, context) =>
+  errorHandler.handleError(error, context, getActiveLanguage());
 
 export async function updateOrderStatus(orderId, newStatus, notes = '') {
   try {
@@ -37,7 +41,7 @@ export async function updateOrderStatus(orderId, newStatus, notes = '') {
     return orderModel.toObject();
 
   } catch (error) {
-    throw errorHandler.handleError(error, `order-status:${orderId}`);
+    throw handleErrorWithLanguage(error, `order-status:${orderId}`);
   }
 }
 
@@ -82,6 +86,6 @@ export async function updateOrderStage(orderId, newStage, notes = '') {
     return orderModel.toObject();
 
   } catch (error) {
-    throw errorHandler.handleError(error, `order-stage:${orderId}`);
+    throw handleErrorWithLanguage(error, `order-stage:${orderId}`);
   }
 }

--- a/src/pages/CheckoutPage.jsx
+++ b/src/pages/CheckoutPage.jsx
@@ -34,7 +34,8 @@ import {
 } from 'lucide-react';
 
 const CheckoutPage = ({ cart, setCart }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const activeLanguage = i18n.language || i18n.resolvedLanguage || 'ar';
   const navigate = useNavigate();
   const { currency } = useCurrency();
   
@@ -851,7 +852,7 @@ const CheckoutPage = ({ cart, setCart }) => {
       
       // عرض رسالة الخطأ فقط إذا كان هناك خطأ حقيقي
       if (error.message && !error.message.includes('auth/user-not-found') && !error.message.includes('auth/invalid-email')) {
-        const errorObject = errorHandler.handleError(error, 'checkout:initialize');
+        const errorObject = errorHandler.handleError(error, 'checkout:initialize', activeLanguage);
         setTimeout(() => {
           toast({
             title: 'خطأ في تحميل بيانات الطلب',
@@ -953,7 +954,7 @@ const CheckoutPage = ({ cart, setCart }) => {
         });
       }, 0);
     } catch (error) {
-      const errorObject = errorHandler.handleError(error, 'checkout:add-address');
+      const errorObject = errorHandler.handleError(error, 'checkout:add-address', activeLanguage);
       setTimeout(() => {
         toast({
           title: 'خطأ في إضافة العنوان',
@@ -988,7 +989,7 @@ const CheckoutPage = ({ cart, setCart }) => {
         });
       }, 0);
     } catch (error) {
-      const errorObject = errorHandler.handleError(error, 'checkout:add-payment');
+      const errorObject = errorHandler.handleError(error, 'checkout:add-payment', activeLanguage);
       setTimeout(() => {
         toast({
           title: 'خطأ في إضافة طريقة الدفع',
@@ -1391,7 +1392,7 @@ const CheckoutPage = ({ cart, setCart }) => {
       navigate(`/orders/${orderResult.id}?success=true`);
 
     } catch (error) {
-      const errorObject = errorHandler.handleError(error, 'checkout:place-order');
+      const errorObject = errorHandler.handleError(error, 'checkout:place-order', activeLanguage);
       logger.error('CheckoutPage - Order creation failed:', errorObject);
       
       setTimeout(() => {

--- a/tests/errorHandler.test.js
+++ b/tests/errorHandler.test.js
@@ -1,0 +1,47 @@
+import { errorHandler } from '../src/lib/errorHandler.js';
+
+describe('errorHandler localization', () => {
+  let originalResolver;
+
+  beforeEach(() => {
+    originalResolver = errorHandler.languageResolver;
+  });
+
+  afterEach(() => {
+    if (typeof originalResolver === 'function') {
+      errorHandler.setLanguageResolver(originalResolver);
+    }
+  });
+
+  it('returns Arabic messages when language is set to ar', () => {
+    const error = new Error('Unknown error');
+    error.code = 'auth/user-not-found';
+
+    const result = errorHandler.handleError(error, 'test:arabic', 'ar');
+
+    expect(result.message).toBe('البريد الإلكتروني غير مسجل');
+    expect(result.language).toBe('ar');
+  });
+
+  it('returns English messages when language is set to en', () => {
+    const error = new Error('Unknown error');
+    error.code = 'auth/user-not-found';
+
+    const result = errorHandler.handleError(error, 'test:english', 'en');
+
+    expect(result.message).toBe('Email not registered');
+    expect(result.language).toBe('en');
+  });
+
+  it('uses the resolver when language is not provided', () => {
+    const error = new Error('Unknown error');
+    error.code = 'auth/wrong-password';
+
+    errorHandler.setLanguageResolver(() => 'en');
+
+    const result = errorHandler.handleError(error, 'test:resolver');
+
+    expect(result.message).toBe('Incorrect password');
+    expect(result.language).toBe('en');
+  });
+});


### PR DESCRIPTION
## Summary
- extend the error handler to resolve languages via a shared utility and supply localized strings for many error codes
- pass the active i18n language from React components and service layers when handling errors so messages localize correctly
- add a Jest test that verifies Arabic and English error messages resolve as expected and harden logger/import.meta guards

## Testing
- NODE_OPTIONS=--experimental-vm-modules npm test *(fails: Firebase configuration and emulator host not provided in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4c4bcc74832ab8ce83c5e2c8d386