### PR TITLE
Ensure locale dictionaries stay in sync with UI usage

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -86,6 +86,12 @@ firebase deploy --only hosting # نشر Hosting فقط
 firebase deploy --only functions # نشر Functions فقط
 ```
 
+### **أوامر الترجمة:**
+```bash
+npm run check:translations      # يتحقق من المفاتيح المفقودة في الواجهة
+npm run sync:locales            # ينسخ ملفات الترجمة من src/locales إلى functions/locales
+```
+
 ### **Firebase Emulators:**
 ```bash
 # تشغيل جميع Emulators

--- a/functions/locales/ar.json
+++ b/functions/locales/ar.json
@@ -8,7 +8,7 @@
   "edit": "تعديل",
   "delete": "حذف",
   "save": "حفظ",
-  "cancel": "إلغاء",
+  "cancel": "ملغي",
   "language": "اللغة",
   "arabic": "العربية",
   "english": "الإنجليزية",
@@ -27,6 +27,9 @@
   "analytics": "التحليلات",
   "marketing": "التسويق",
   "promotions": "العروض",
+  "features": "الميزات",
+  "sliders": "الشرائح",
+  "banners": "البانرات",
   "branches": "الفروع",
   "subscriptions": "الاشتراكات",
   "logout": "تسجيل الخروج",
@@ -60,7 +63,6 @@
   "unpaid": "غير مدفوع",
   "refund": "مسترد",
   "waiting": "في الانتظار",
-  "cancel": "ملغي",
   "shipped": "مشحون",
   "delivered": "مسلم",
   "pending": "معلق",
@@ -95,6 +97,7 @@
   "my_account": "حسابي",
   "my_library": "مكتبتي",
   "my_orders": "مشترياتي",
+  "view_cart": "عرض السلة",
   "login_or_register": "تسجيل الدخول / إنشاء حساب",
   "category_fiction": "الخيال",
   "category_nonfiction": "غير الخيال",
@@ -110,9 +113,15 @@
   "brands": "العلامات التجارية",
   "choose_delivery_method": "اختر طريقة التوصيل",
   "search_suggestions": "اقتراحات البحث",
+  "clear_search_history": "مسح سجل البحث",
+  "recent_searches_cleared": "تم مسح سجل البحث",
+  "open_search_panel": "فتح لوحة البحث",
+  "close_search_panel": "إغلاق لوحة البحث",
   "quick_browse": "تصفح سريع",
   "delivery_methods": "طرق التوصيل",
   "menu": "القائمة",
+  "open_navigation_menu": "فتح قائمة التنقل",
+  "close_navigation_menu": "إغلاق قائمة التنقل",
   "main_pages": "الصفحات الرئيسية",
   "home": "الرئيسية",
   "most_popular": "الأكثر شيوعاً",
@@ -149,6 +158,7 @@
   "ebooks": "الكتب الإلكترونية",
   "search_title": "البحث",
   "search_books_placeholder": "ابحث في الكتب...",
+  "submit_search": "بحث",
   "home_bestsellers_audiobooks": "الكتب الصوتية الأكثر مبيعاً",
   "home_bestsellers_all_books": "الكتب الأكثر مبيعاً",
   "app": {
@@ -161,25 +171,63 @@
           "title": "خطأ في تحميل البيانات"
         },
         "description": "{{message}}",
-        "books": { "title": "تعذر تحميل قائمة الكتب" },
-        "authors": { "title": "تعذر تحميل قائمة المؤلفين" },
-        "categories": { "title": "تعذر تحميل الفئات" },
-        "settings": { "title": "تعذر تحميل الإعدادات" },
-        "orders": { "title": "تعذر تحميل الطلبات" },
-        "payments": { "title": "تعذر تحميل المدفوعات" },
-        "paymentMethods": { "title": "تعذر تحميل طرق الدفع" },
-        "currencies": { "title": "تعذر تحميل العملات" },
-        "languages": { "title": "تعذر تحميل اللغات" },
-        "plans": { "title": "تعذر تحميل الخطط" },
-        "users": { "title": "تعذر تحميل المستخدمين" },
-        "sliders": { "title": "تعذر تحميل الشرائح" },
-        "banners": { "title": "تعذر تحميل البانرات" },
-        "features": { "title": "تعذر تحميل الميزات" },
-        "sellers": { "title": "تعذر تحميل البائعين" },
-        "branches": { "title": "تعذر تحميل الفروع" },
-        "subscriptions": { "title": "تعذر تحميل الاشتراكات" },
-        "messages": { "title": "تعذر تحميل الرسائل" },
-        "initialLoad": { "title": "تعذر تحميل البيانات" }
+        "books": {
+          "title": "تعذر تحميل قائمة الكتب"
+        },
+        "authors": {
+          "title": "تعذر تحميل قائمة المؤلفين"
+        },
+        "categories": {
+          "title": "تعذر تحميل الفئات"
+        },
+        "settings": {
+          "title": "تعذر تحميل الإعدادات"
+        },
+        "orders": {
+          "title": "تعذر تحميل الطلبات"
+        },
+        "payments": {
+          "title": "تعذر تحميل المدفوعات"
+        },
+        "paymentMethods": {
+          "title": "تعذر تحميل طرق الدفع"
+        },
+        "currencies": {
+          "title": "تعذر تحميل العملات"
+        },
+        "languages": {
+          "title": "تعذر تحميل اللغات"
+        },
+        "plans": {
+          "title": "تعذر تحميل الخطط"
+        },
+        "users": {
+          "title": "تعذر تحميل المستخدمين"
+        },
+        "sliders": {
+          "title": "تعذر تحميل الشرائح"
+        },
+        "banners": {
+          "title": "تعذر تحميل البانرات"
+        },
+        "features": {
+          "title": "تعذر تحميل الميزات"
+        },
+        "sellers": {
+          "title": "تعذر تحميل البائعين"
+        },
+        "branches": {
+          "title": "تعذر تحميل الفروع"
+        },
+        "subscriptions": {
+          "title": "تعذر تحميل الاشتراكات"
+        },
+        "messages": {
+          "title": "تعذر تحميل الرسائل"
+        },
+        "initialLoad": {
+          "title": "تعذر تحميل البيانات"
+        }
       },
       "cart": {
         "remove": {
@@ -333,8 +381,12 @@
       }
     },
     "sellers": {
-      "seller1": { "name": "مكتبة المعرفة" },
-      "seller2": { "name": "دار الحكمة" }
+      "seller1": {
+        "name": "مكتبة المعرفة"
+      },
+      "seller2": {
+        "name": "دار الحكمة"
+      }
     },
     "branches": {
       "branch1": {

--- a/functions/locales/en.json
+++ b/functions/locales/en.json
@@ -27,6 +27,9 @@
   "analytics": "Analytics",
   "marketing": "Marketing",
   "promotions": "Promotions",
+  "features": "Features",
+  "sliders": "Sliders",
+  "banners": "Banners",
   "branches": "Branches",
   "subscriptions": "Subscriptions",
   "logout": "Logout",
@@ -60,7 +63,6 @@
   "unpaid": "Unpaid",
   "refund": "Refund",
   "waiting": "Waiting",
-  "cancel": "Cancel",
   "shipped": "Shipped",
   "delivered": "Delivered",
   "pending": "Pending",
@@ -95,6 +97,7 @@
   "my_account": "My Account",
   "my_library": "My Library",
   "my_orders": "My Orders",
+  "view_cart": "View cart",
   "login_or_register": "Sign In / Create Account",
   "category_fiction": "Fiction",
   "category_nonfiction": "Nonfiction",
@@ -110,9 +113,15 @@
   "brands": "Brands",
   "choose_delivery_method": "Choose Delivery Method",
   "search_suggestions": "Search Suggestions",
+  "clear_search_history": "Clear history",
+  "recent_searches_cleared": "Search history cleared",
+  "open_search_panel": "Open search panel",
+  "close_search_panel": "Close search panel",
   "quick_browse": "Quick Browse",
   "delivery_methods": "Delivery Methods",
   "menu": "Menu",
+  "open_navigation_menu": "Open navigation menu",
+  "close_navigation_menu": "Close navigation menu",
   "main_pages": "Main Pages",
   "home": "Home",
   "most_popular": "Most Popular",
@@ -149,6 +158,7 @@
   "ebooks": "Ebooks",
   "search_title": "Search",
   "search_books_placeholder": "Search books...",
+  "submit_search": "Search",
   "home_bestsellers_audiobooks": "Top-selling audiobooks",
   "home_bestsellers_all_books": "Best-selling books",
   "app": {
@@ -161,25 +171,63 @@
           "title": "Error loading data"
         },
         "description": "{{message}}",
-        "books": { "title": "We couldn't load the books" },
-        "authors": { "title": "We couldn't load the authors" },
-        "categories": { "title": "We couldn't load the categories" },
-        "settings": { "title": "We couldn't load the settings" },
-        "orders": { "title": "We couldn't load the orders" },
-        "payments": { "title": "We couldn't load the payments" },
-        "paymentMethods": { "title": "We couldn't load the payment methods" },
-        "currencies": { "title": "We couldn't load the currencies" },
-        "languages": { "title": "We couldn't load the languages" },
-        "plans": { "title": "We couldn't load the plans" },
-        "users": { "title": "We couldn't load the users" },
-        "sliders": { "title": "We couldn't load the sliders" },
-        "banners": { "title": "We couldn't load the banners" },
-        "features": { "title": "We couldn't load the features" },
-        "sellers": { "title": "We couldn't load the sellers" },
-        "branches": { "title": "We couldn't load the branches" },
-        "subscriptions": { "title": "We couldn't load the subscriptions" },
-        "messages": { "title": "We couldn't load the messages" },
-        "initialLoad": { "title": "We couldn't load the data" }
+        "books": {
+          "title": "We couldn't load the books"
+        },
+        "authors": {
+          "title": "We couldn't load the authors"
+        },
+        "categories": {
+          "title": "We couldn't load the categories"
+        },
+        "settings": {
+          "title": "We couldn't load the settings"
+        },
+        "orders": {
+          "title": "We couldn't load the orders"
+        },
+        "payments": {
+          "title": "We couldn't load the payments"
+        },
+        "paymentMethods": {
+          "title": "We couldn't load the payment methods"
+        },
+        "currencies": {
+          "title": "We couldn't load the currencies"
+        },
+        "languages": {
+          "title": "We couldn't load the languages"
+        },
+        "plans": {
+          "title": "We couldn't load the plans"
+        },
+        "users": {
+          "title": "We couldn't load the users"
+        },
+        "sliders": {
+          "title": "We couldn't load the sliders"
+        },
+        "banners": {
+          "title": "We couldn't load the banners"
+        },
+        "features": {
+          "title": "We couldn't load the features"
+        },
+        "sellers": {
+          "title": "We couldn't load the sellers"
+        },
+        "branches": {
+          "title": "We couldn't load the branches"
+        },
+        "subscriptions": {
+          "title": "We couldn't load the subscriptions"
+        },
+        "messages": {
+          "title": "We couldn't load the messages"
+        },
+        "initialLoad": {
+          "title": "We couldn't load the data"
+        }
       },
       "cart": {
         "remove": {
@@ -333,8 +381,12 @@
       }
     },
     "sellers": {
-      "seller1": { "name": "Knowledge Bookstore" },
-      "seller2": { "name": "Dar Al Hikma" }
+      "seller1": {
+        "name": "Knowledge Bookstore"
+      },
+      "seller2": {
+        "name": "Dar Al Hikma"
+      }
     },
     "branches": {
       "branch1": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "firebase:deploy": "firebase deploy",
     "firebase:deploy:hosting": "firebase deploy --only hosting",
     "firebase:deploy:functions": "firebase deploy --only functions",
-    "firebase:deploy:firestore": "firebase deploy --only firestore"
+    "firebase:deploy:firestore": "firebase deploy --only firestore",
+    "sync:locales": "node scripts/sync-locales.mjs",
+    "check:translations": "python3 scripts/find_missing_translations.py"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "^1.2.1",

--- a/scripts/find_missing_translations.py
+++ b/scripts/find_missing_translations.py
@@ -1,0 +1,62 @@
+import json
+import os
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = PROJECT_ROOT / 'src'
+LOCALE_FILE = PROJECT_ROOT / 'src' / 'locales' / 'en.json'
+IGNORED_DIRS = {'.git', 'node_modules', 'dist', 'build', '.cache', '.next', 'coverage', 'public'}
+
+KEY_PATTERN = re.compile(r"\bt\(\s*([\"'`])([^\"'`]+?)\1", re.MULTILINE)
+
+
+def flatten_keys(obj, prefix=""):
+    keys = set()
+
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            full_key = f"{prefix}.{key}" if prefix else key
+            if isinstance(value, dict):
+                keys.update(flatten_keys(value, full_key))
+            else:
+                keys.add(full_key)
+    return keys
+
+
+def walk_source_files(root: Path):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRS]
+        for filename in filenames:
+            if filename.endswith(('.js', '.jsx', '.ts', '.tsx')):
+                yield Path(dirpath) / filename
+
+
+def main():
+    translation_keys = flatten_keys(json.loads(LOCALE_FILE.read_text(encoding='utf-8')))
+    used_keys = set()
+    dynamic_keys = set()
+
+    for file_path in walk_source_files(SRC_DIR):
+        source = file_path.read_text(encoding='utf-8')
+        for match in KEY_PATTERN.finditer(source):
+            key = match.group(2)
+            if '${' in key:
+                dynamic_keys.add(key)
+                continue
+            used_keys.add(key)
+
+    missing_keys = sorted(key for key in used_keys if key not in translation_keys)
+
+    result = {
+        'missingKeys': missing_keys,
+        'usedKeyCount': len(used_keys),
+        'translationKeyCount': len(translation_keys),
+        'dynamicKeys': sorted(dynamic_keys),
+    }
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/sync-locales.mjs
+++ b/scripts/sync-locales.mjs
@@ -1,0 +1,56 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const sourceDir = path.join(projectRoot, 'src', 'locales');
+const targetDir = path.join(projectRoot, 'functions', 'locales');
+
+async function ensureTargetDir() {
+  await fs.mkdir(targetDir, { recursive: true });
+}
+
+async function copyLocaleFile(fileName) {
+  const sourcePath = path.join(sourceDir, fileName);
+  const targetPath = path.join(targetDir, fileName);
+  const contents = await fs.readFile(sourcePath, 'utf8');
+  await fs.writeFile(targetPath, contents, 'utf8');
+  return targetPath;
+}
+
+async function syncLocales() {
+  await ensureTargetDir();
+  const entries = await fs.readdir(sourceDir, { withFileTypes: true });
+  const copied = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    if (!entry.name.endsWith('.json')) {
+      continue;
+    }
+
+    const resultPath = await copyLocaleFile(entry.name);
+    copied.push(path.relative(projectRoot, resultPath));
+  }
+
+  return copied;
+}
+
+syncLocales()
+  .then((copied) => {
+    if (copied.length) {
+      console.log(`Synced ${copied.length} locale file(s):`);
+      copied.forEach((filePath) => console.log(` - ${filePath}`));
+    } else {
+      console.log('No locale files found to sync.');
+    }
+  })
+  .catch((error) => {
+    console.error('Failed to sync locales:', error);
+    process.exitCode = 1;
+  });

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -8,7 +8,7 @@
   "edit": "تعديل",
   "delete": "حذف",
   "save": "حفظ",
-  "cancel": "إلغاء",
+  "cancel": "ملغي",
   "language": "اللغة",
   "arabic": "العربية",
   "english": "الإنجليزية",
@@ -27,6 +27,9 @@
   "analytics": "التحليلات",
   "marketing": "التسويق",
   "promotions": "العروض",
+  "features": "الميزات",
+  "sliders": "الشرائح",
+  "banners": "البانرات",
   "branches": "الفروع",
   "subscriptions": "الاشتراكات",
   "logout": "تسجيل الخروج",
@@ -60,7 +63,6 @@
   "unpaid": "غير مدفوع",
   "refund": "مسترد",
   "waiting": "في الانتظار",
-  "cancel": "ملغي",
   "shipped": "مشحون",
   "delivered": "مسلم",
   "pending": "معلق",
@@ -95,6 +97,7 @@
   "my_account": "حسابي",
   "my_library": "مكتبتي",
   "my_orders": "مشترياتي",
+  "view_cart": "عرض السلة",
   "login_or_register": "تسجيل الدخول / إنشاء حساب",
   "category_fiction": "الخيال",
   "category_nonfiction": "غير الخيال",
@@ -110,9 +113,15 @@
   "brands": "العلامات التجارية",
   "choose_delivery_method": "اختر طريقة التوصيل",
   "search_suggestions": "اقتراحات البحث",
+  "clear_search_history": "مسح سجل البحث",
+  "recent_searches_cleared": "تم مسح سجل البحث",
+  "open_search_panel": "فتح لوحة البحث",
+  "close_search_panel": "إغلاق لوحة البحث",
   "quick_browse": "تصفح سريع",
   "delivery_methods": "طرق التوصيل",
   "menu": "القائمة",
+  "open_navigation_menu": "فتح قائمة التنقل",
+  "close_navigation_menu": "إغلاق قائمة التنقل",
   "main_pages": "الصفحات الرئيسية",
   "home": "الرئيسية",
   "most_popular": "الأكثر شيوعاً",
@@ -149,6 +158,7 @@
   "ebooks": "الكتب الإلكترونية",
   "search_title": "البحث",
   "search_books_placeholder": "ابحث في الكتب...",
+  "submit_search": "بحث",
   "home_bestsellers_audiobooks": "الكتب الصوتية الأكثر مبيعاً",
   "home_bestsellers_all_books": "الكتب الأكثر مبيعاً",
   "app": {
@@ -161,25 +171,63 @@
           "title": "خطأ في تحميل البيانات"
         },
         "description": "{{message}}",
-        "books": { "title": "تعذر تحميل قائمة الكتب" },
-        "authors": { "title": "تعذر تحميل قائمة المؤلفين" },
-        "categories": { "title": "تعذر تحميل الفئات" },
-        "settings": { "title": "تعذر تحميل الإعدادات" },
-        "orders": { "title": "تعذر تحميل الطلبات" },
-        "payments": { "title": "تعذر تحميل المدفوعات" },
-        "paymentMethods": { "title": "تعذر تحميل طرق الدفع" },
-        "currencies": { "title": "تعذر تحميل العملات" },
-        "languages": { "title": "تعذر تحميل اللغات" },
-        "plans": { "title": "تعذر تحميل الخطط" },
-        "users": { "title": "تعذر تحميل المستخدمين" },
-        "sliders": { "title": "تعذر تحميل الشرائح" },
-        "banners": { "title": "تعذر تحميل البانرات" },
-        "features": { "title": "تعذر تحميل الميزات" },
-        "sellers": { "title": "تعذر تحميل البائعين" },
-        "branches": { "title": "تعذر تحميل الفروع" },
-        "subscriptions": { "title": "تعذر تحميل الاشتراكات" },
-        "messages": { "title": "تعذر تحميل الرسائل" },
-        "initialLoad": { "title": "تعذر تحميل البيانات" }
+        "books": {
+          "title": "تعذر تحميل قائمة الكتب"
+        },
+        "authors": {
+          "title": "تعذر تحميل قائمة المؤلفين"
+        },
+        "categories": {
+          "title": "تعذر تحميل الفئات"
+        },
+        "settings": {
+          "title": "تعذر تحميل الإعدادات"
+        },
+        "orders": {
+          "title": "تعذر تحميل الطلبات"
+        },
+        "payments": {
+          "title": "تعذر تحميل المدفوعات"
+        },
+        "paymentMethods": {
+          "title": "تعذر تحميل طرق الدفع"
+        },
+        "currencies": {
+          "title": "تعذر تحميل العملات"
+        },
+        "languages": {
+          "title": "تعذر تحميل اللغات"
+        },
+        "plans": {
+          "title": "تعذر تحميل الخطط"
+        },
+        "users": {
+          "title": "تعذر تحميل المستخدمين"
+        },
+        "sliders": {
+          "title": "تعذر تحميل الشرائح"
+        },
+        "banners": {
+          "title": "تعذر تحميل البانرات"
+        },
+        "features": {
+          "title": "تعذر تحميل الميزات"
+        },
+        "sellers": {
+          "title": "تعذر تحميل البائعين"
+        },
+        "branches": {
+          "title": "تعذر تحميل الفروع"
+        },
+        "subscriptions": {
+          "title": "تعذر تحميل الاشتراكات"
+        },
+        "messages": {
+          "title": "تعذر تحميل الرسائل"
+        },
+        "initialLoad": {
+          "title": "تعذر تحميل البيانات"
+        }
       },
       "cart": {
         "remove": {
@@ -333,8 +381,12 @@
       }
     },
     "sellers": {
-      "seller1": { "name": "مكتبة المعرفة" },
-      "seller2": { "name": "دار الحكمة" }
+      "seller1": {
+        "name": "مكتبة المعرفة"
+      },
+      "seller2": {
+        "name": "دار الحكمة"
+      }
     },
     "branches": {
       "branch1": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -27,6 +27,9 @@
   "analytics": "Analytics",
   "marketing": "Marketing",
   "promotions": "Promotions",
+  "features": "Features",
+  "sliders": "Sliders",
+  "banners": "Banners",
   "branches": "Branches",
   "subscriptions": "Subscriptions",
   "logout": "Logout",
@@ -60,7 +63,6 @@
   "unpaid": "Unpaid",
   "refund": "Refund",
   "waiting": "Waiting",
-  "cancel": "Cancel",
   "shipped": "Shipped",
   "delivered": "Delivered",
   "pending": "Pending",
@@ -95,6 +97,7 @@
   "my_account": "My Account",
   "my_library": "My Library",
   "my_orders": "My Orders",
+  "view_cart": "View cart",
   "login_or_register": "Sign In / Create Account",
   "category_fiction": "Fiction",
   "category_nonfiction": "Nonfiction",
@@ -110,9 +113,15 @@
   "brands": "Brands",
   "choose_delivery_method": "Choose Delivery Method",
   "search_suggestions": "Search Suggestions",
+  "clear_search_history": "Clear history",
+  "recent_searches_cleared": "Search history cleared",
+  "open_search_panel": "Open search panel",
+  "close_search_panel": "Close search panel",
   "quick_browse": "Quick Browse",
   "delivery_methods": "Delivery Methods",
   "menu": "Menu",
+  "open_navigation_menu": "Open navigation menu",
+  "close_navigation_menu": "Close navigation menu",
   "main_pages": "Main Pages",
   "home": "Home",
   "most_popular": "Most Popular",
@@ -149,6 +158,7 @@
   "ebooks": "Ebooks",
   "search_title": "Search",
   "search_books_placeholder": "Search books...",
+  "submit_search": "Search",
   "home_bestsellers_audiobooks": "Top-selling audiobooks",
   "home_bestsellers_all_books": "Best-selling books",
   "app": {
@@ -161,25 +171,63 @@
           "title": "Error loading data"
         },
         "description": "{{message}}",
-        "books": { "title": "We couldn't load the books" },
-        "authors": { "title": "We couldn't load the authors" },
-        "categories": { "title": "We couldn't load the categories" },
-        "settings": { "title": "We couldn't load the settings" },
-        "orders": { "title": "We couldn't load the orders" },
-        "payments": { "title": "We couldn't load the payments" },
-        "paymentMethods": { "title": "We couldn't load the payment methods" },
-        "currencies": { "title": "We couldn't load the currencies" },
-        "languages": { "title": "We couldn't load the languages" },
-        "plans": { "title": "We couldn't load the plans" },
-        "users": { "title": "We couldn't load the users" },
-        "sliders": { "title": "We couldn't load the sliders" },
-        "banners": { "title": "We couldn't load the banners" },
-        "features": { "title": "We couldn't load the features" },
-        "sellers": { "title": "We couldn't load the sellers" },
-        "branches": { "title": "We couldn't load the branches" },
-        "subscriptions": { "title": "We couldn't load the subscriptions" },
-        "messages": { "title": "We couldn't load the messages" },
-        "initialLoad": { "title": "We couldn't load the data" }
+        "books": {
+          "title": "We couldn't load the books"
+        },
+        "authors": {
+          "title": "We couldn't load the authors"
+        },
+        "categories": {
+          "title": "We couldn't load the categories"
+        },
+        "settings": {
+          "title": "We couldn't load the settings"
+        },
+        "orders": {
+          "title": "We couldn't load the orders"
+        },
+        "payments": {
+          "title": "We couldn't load the payments"
+        },
+        "paymentMethods": {
+          "title": "We couldn't load the payment methods"
+        },
+        "currencies": {
+          "title": "We couldn't load the currencies"
+        },
+        "languages": {
+          "title": "We couldn't load the languages"
+        },
+        "plans": {
+          "title": "We couldn't load the plans"
+        },
+        "users": {
+          "title": "We couldn't load the users"
+        },
+        "sliders": {
+          "title": "We couldn't load the sliders"
+        },
+        "banners": {
+          "title": "We couldn't load the banners"
+        },
+        "features": {
+          "title": "We couldn't load the features"
+        },
+        "sellers": {
+          "title": "We couldn't load the sellers"
+        },
+        "branches": {
+          "title": "We couldn't load the branches"
+        },
+        "subscriptions": {
+          "title": "We couldn't load the subscriptions"
+        },
+        "messages": {
+          "title": "We couldn't load the messages"
+        },
+        "initialLoad": {
+          "title": "We couldn't load the data"
+        }
       },
       "cart": {
         "remove": {
@@ -333,8 +381,12 @@
       }
     },
     "sellers": {
-      "seller1": { "name": "Knowledge Bookstore" },
-      "seller2": { "name": "Dar Al Hikma" }
+      "seller1": {
+        "name": "Knowledge Bookstore"
+      },
+      "seller2": {
+        "name": "Dar Al Hikma"
+      }
     },
     "branches": {
       "branch1": {

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -70,7 +70,7 @@ const HomePage = ({
             handleAddToCart={handleAddToCart}
             handleToggleWishlist={handleToggleWishlist}
             wishlist={wishlist}
-          title={t('home.bestsellers.audiobooks', { defaultValue: 'Top-selling audiobooks' })}
+          title={t('home_bestsellers_audiobooks', { defaultValue: 'Top-selling audiobooks' })}
           icon={TrendingUp}
           squareImages
         />
@@ -81,7 +81,7 @@ const HomePage = ({
             handleAddToCart={handleAddToCart}
             handleToggleWishlist={handleToggleWishlist}
             wishlist={wishlist}
-          title={t('home.bestsellers.allBooks', { defaultValue: 'Best-selling books' })}
+          title={t('home_bestsellers_all_books', { defaultValue: 'Best-selling books' })}
           icon={TrendingUp}
           bgColor="bg-slate-100"
           likeCardStyle


### PR DESCRIPTION
## Summary
- add missing navigation, search, and cart translation strings in both Arabic and English locales and mirror them under functions/locales
- update the home page bestseller widgets to use the existing flattened locale keys
- add scripts for auditing missing translation keys and syncing locale files, and document the workflow in the developer guide

## Testing
- python3 scripts/find_missing_translations.py

------
https://chatgpt.com/codex/tasks/task_e_68ce50a93214832a89f728e2e7aa0d44