### PR TITLE
Expose dashboard stats callable via firebaseApi

### DIFF
--- a/src/lib/firebaseApi.js
+++ b/src/lib/firebaseApi.js
@@ -6,6 +6,7 @@ import messagesApi from './firebase/messagesApi.js';
 import settingsApi from './firebase/settingsApi.js';
 import ratingsApi from './firebase/ratingsApi.js';
 import homeApi from './firebase/homeApi.js';
+import firebaseFunctionsApi from './firebaseFunctions.js';
 
 // Aggregate all domain APIs into a single object for backwards compatibility
 export default {
@@ -16,5 +17,6 @@ export default {
   ...messagesApi,
   ...settingsApi,
   ...ratingsApi,
-  ...homeApi
+  ...homeApi,
+  getDashboardStats: () => firebaseFunctionsApi.analytics.getDashboardStats()
 };


### PR DESCRIPTION
## Summary
- import the firebaseFunctions helpers in the firebaseApi aggregator
- surface the analytics getDashboardStats callable through the default firebaseApi export so the admin dashboard can resolve it

## Testing
- npm test -- --runTestsByPath tests/adminDashboard.test.js *(fails: tests/adminDashboard.test.js missing in repository)*
- npm test -- --watchAll=false *(fails: jest configuration lacks ESM support for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ce74f8ed60832ab9b67e6cb6056f62